### PR TITLE
fix: convert plugin manifests to array format for Claude compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "generate:agents": "node scripts/generate-markdown.js --type agents",
     "generate:watch": "node scripts/generate-markdown.js --watch",
     "generate:validate": "node scripts/generate-markdown.js --validate",
+    "fix-manifests": "node scripts/fix-plugin-manifests.js",
     "publish:changed": "node scripts/publish-plugin.js"
   },
   "devDependencies": {

--- a/packages/agent-progress-pane/.claude-plugin/plugin.json
+++ b/packages/agent-progress-pane/.claude-plugin/plugin.json
@@ -18,7 +18,9 @@
     "ensemble"
   ],
   "hooks": "./hooks/hooks.json",
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/agent-progress-config.md"
+  ],
+  "skills": [],
+  "agents": []
 }

--- a/packages/blazor/.claude-plugin/plugin.json
+++ b/packages/blazor/.claude-plugin/plugin.json
@@ -15,7 +15,11 @@
     "frontend",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/dotnet-framework",
+    "././skills/examples",
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/core/.claude-plugin/plugin.json
+++ b/packages/core/.claude-plugin/plugin.json
@@ -15,7 +15,20 @@
     "ensemble",
     "framework-detection"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/fold-prompt.md",
+    "././commands/ensemble/init-project.md"
+  ],
+  "skills": [
+    "././skills/framework-detector",
+    "././skills/test-detector"
+  ],
+  "agents": [
+    "././agents/agent-meta-engineer.md",
+    "././agents/context-fetcher.md",
+    "././agents/directory-monitor.md",
+    "././agents/ensemble-orchestrator.md",
+    "././agents/file-creator.md",
+    "././agents/general-purpose.md"
+  ]
 }

--- a/packages/development/.claude-plugin/plugin.json
+++ b/packages/development/.claude-plugin/plugin.json
@@ -15,7 +15,18 @@
     "coding",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/create-trd.md",
+    "././commands/ensemble/generate-api-docs.md",
+    "././commands/ensemble/implement-trd.md",
+    "././commands/ensemble/refine-trd.md"
+  ],
+  "skills": [],
+  "agents": [
+    "././agents/api-documentation-specialist.md",
+    "././agents/backend-developer.md",
+    "././agents/documentation-specialist.md",
+    "././agents/frontend-developer.md",
+    "././agents/tech-lead-orchestrator.md"
+  ]
 }

--- a/packages/e2e-testing/.claude-plugin/plugin.json
+++ b/packages/e2e-testing/.claude-plugin/plugin.json
@@ -15,7 +15,18 @@
     "testing",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/playwright-test.md"
+  ],
+  "skills": [
+    "././skills/smoke-test-api",
+    "././skills/smoke-test-auth",
+    "././skills/smoke-test-critical-paths",
+    "././skills/smoke-test-database",
+    "././skills/smoke-test-external-services",
+    "././skills/smoke-test-runner"
+  ],
+  "agents": [
+    "././agents/playwright-tester.md"
+  ]
 }

--- a/packages/exunit/.claude-plugin/plugin.json
+++ b/packages/exunit/.claude-plugin/plugin.json
@@ -15,7 +15,7 @@
     "elixir",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [],
+  "agents": []
 }

--- a/packages/full/.claude-plugin/plugin.json
+++ b/packages/full/.claude-plugin/plugin.json
@@ -15,7 +15,25 @@
     "meta",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/agent-progress-config.md",
+    "././commands/task-progress-config.md"
+  ],
+  "skills": [
+    "././skills/blazor",
+    "././skills/core",
+    "././skills/e2e-testing",
+    "././skills/exunit",
+    "././skills/git",
+    "././skills/infrastructure",
+    "././skills/jest",
+    "././skills/nestjs",
+    "././skills/phoenix",
+    "././skills/pytest",
+    "././skills/rails",
+    "././skills/react",
+    "././skills/rspec",
+    "././skills/xunit"
+  ],
+  "agents": []
 }

--- a/packages/git/.claude-plugin/plugin.json
+++ b/packages/git/.claude-plugin/plugin.json
@@ -15,7 +15,16 @@
     "commits",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/claude-changelog.md",
+    "././commands/ensemble/release.md"
+  ],
+  "skills": [
+    "././skills/changelog-generator"
+  ],
+  "agents": [
+    "././agents/git-workflow.md",
+    "././agents/github-specialist.md",
+    "././agents/release-agent.md"
+  ]
 }

--- a/packages/infrastructure/.claude-plugin/plugin.json
+++ b/packages/infrastructure/.claude-plugin/plugin.json
@@ -16,7 +16,21 @@
     "aws",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/aws-cloud",
+    "././skills/cloud-provider-detector",
+    "././skills/flyio",
+    "././skills/helm",
+    "././skills/kubernetes",
+    "././skills/tooling-detector"
+  ],
+  "agents": [
+    "././agents/build-orchestrator.md",
+    "././agents/deployment-orchestrator.md",
+    "././agents/helm-chart-specialist.md",
+    "././agents/infrastructure-developer.md",
+    "././agents/infrastructure-orchestrator.md",
+    "././agents/postgresql-specialist.md"
+  ]
 }

--- a/packages/jest/.claude-plugin/plugin.json
+++ b/packages/jest/.claude-plugin/plugin.json
@@ -15,7 +15,9 @@
     "javascript",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/metrics/.claude-plugin/plugin.json
+++ b/packages/metrics/.claude-plugin/plugin.json
@@ -15,7 +15,13 @@
     "dashboard",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/manager-dashboard.md",
+    "././commands/ensemble/sprint-status.md",
+    "././commands/ensemble/web-metrics-dashboard.md"
+  ],
+  "skills": [],
+  "agents": [
+    "././agents/manager-dashboard-agent.md"
+  ]
 }

--- a/packages/nestjs/.claude-plugin/plugin.json
+++ b/packages/nestjs/.claude-plugin/plugin.json
@@ -17,7 +17,10 @@
     "ensemble",
     "framework"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/examples",
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/phoenix/.claude-plugin/plugin.json
+++ b/packages/phoenix/.claude-plugin/plugin.json
@@ -15,7 +15,10 @@
     "liveview",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/examples",
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/product/.claude-plugin/plugin.json
+++ b/packages/product/.claude-plugin/plugin.json
@@ -15,7 +15,13 @@
     "planning",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [
+    "././commands/ensemble/analyze-product.md",
+    "././commands/ensemble/create-prd.md",
+    "././commands/ensemble/refine-prd.md"
+  ],
+  "skills": [],
+  "agents": [
+    "././agents/product-management-orchestrator.md"
+  ]
 }

--- a/packages/pytest/.claude-plugin/plugin.json
+++ b/packages/pytest/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
     "parametrization",
     "test-generation"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [],
+  "agents": []
 }

--- a/packages/quality/.claude-plugin/plugin.json
+++ b/packages/quality/.claude-plugin/plugin.json
@@ -15,7 +15,13 @@
     "testing",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [],
+  "agents": [
+    "././agents/code-reviewer.md",
+    "././agents/deep-debugger.md",
+    "././agents/qa-orchestrator.md",
+    "././agents/test-reader-agent.md",
+    "././agents/test-runner.md"
+  ]
 }

--- a/packages/rails/.claude-plugin/plugin.json
+++ b/packages/rails/.claude-plugin/plugin.json
@@ -15,7 +15,10 @@
     "backend",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/examples",
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/react/.claude-plugin/plugin.json
+++ b/packages/react/.claude-plugin/plugin.json
@@ -18,7 +18,10 @@
     "state-management",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [
+    "././skills/examples",
+    "././skills/templates"
+  ],
+  "agents": []
 }

--- a/packages/rspec/.claude-plugin/plugin.json
+++ b/packages/rspec/.claude-plugin/plugin.json
@@ -15,7 +15,7 @@
     "ruby",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [],
+  "agents": []
 }

--- a/packages/task-progress-pane/.claude-plugin/plugin.json
+++ b/packages/task-progress-pane/.claude-plugin/plugin.json
@@ -9,5 +9,7 @@
   "license": "MIT",
   "repository": "https://github.com/FortiumPartners/ensemble",
   "hooks": "./hooks/hooks.json",
-  "commands": "./commands"
+  "commands": [
+    "././commands/task-progress-config.md"
+  ]
 }

--- a/packages/xunit/.claude-plugin/plugin.json
+++ b/packages/xunit/.claude-plugin/plugin.json
@@ -15,7 +15,7 @@
     "dotnet",
     "ensemble"
   ],
-  "commands": "./commands",
-  "skills": "./skills",
-  "agents": "./agents"
+  "commands": [],
+  "skills": [],
+  "agents": []
 }

--- a/scripts/fix-plugin-manifests.js
+++ b/scripts/fix-plugin-manifests.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+/**
+ * Fix plugin.json manifests to use array format for agents, commands, and skills
+ * 
+ * Changes:
+ * - "agents": "./agents" → "agents": ["./agents/file1.md", "./agents/file2.md", ...]
+ * - "commands": "./commands" → "commands": ["./commands/file1.md", ...]
+ * - "skills": "./skills" → "skills": ["./skills/dir1", "./skills/dir2", ...]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Find all plugin.json files
+const rootDir = path.join(__dirname, '..');
+const packagesDir = path.join(rootDir, 'packages');
+const pluginManifests = [];
+
+if (fs.existsSync(packagesDir)) {
+  const packages = fs.readdirSync(packagesDir);
+  for (const pkg of packages) {
+    const manifestPath = path.join(packagesDir, pkg, '.claude-plugin', 'plugin.json');
+    if (fs.existsSync(manifestPath)) {
+      pluginManifests.push(manifestPath);
+    }
+  }
+}
+
+console.log(`Found ${pluginManifests.length} plugin manifests to fix\n`);
+
+let fixed = 0;
+let skipped = 0;
+let errors = 0;
+
+for (const manifestPath of pluginManifests) {
+  try {
+    const packageDir = path.dirname(path.dirname(manifestPath));
+    const packageName = path.basename(packageDir);
+    
+    console.log(`Processing: ${packageName}`);
+    
+    // Read manifest
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    let modified = false;
+    
+    // Fix agents
+    if (typeof manifest.agents === 'string') {
+      const agentsDir = path.join(packageDir, manifest.agents);
+      if (fs.existsSync(agentsDir)) {
+        const agentFiles = fs.readdirSync(agentsDir)
+          .filter(f => f.endsWith('.md'))
+          .map(f => `./${manifest.agents}/${f}`);
+        
+        if (agentFiles.length > 0) {
+          manifest.agents = agentFiles;
+          console.log(`  ✓ Fixed agents: ${agentFiles.length} files`);
+          modified = true;
+        } else {
+          manifest.agents = [];
+          console.log(`  ✓ Fixed agents: empty array (no .md files found)`);
+          modified = true;
+        }
+      } else {
+        manifest.agents = [];
+        console.log(`  ✓ Fixed agents: empty array (directory not found)`);
+        modified = true;
+      }
+    }
+    
+    // Fix commands
+    if (typeof manifest.commands === 'string') {
+      const commandsDir = path.join(packageDir, manifest.commands);
+      const commandFiles = [];
+      
+      if (fs.existsSync(commandsDir)) {
+        // Check for nested ensemble/ directory structure
+        const ensembleDir = path.join(commandsDir, 'ensemble');
+        if (fs.existsSync(ensembleDir)) {
+          // Use nested structure
+          fs.readdirSync(ensembleDir)
+            .filter(f => f.endsWith('.md'))
+            .forEach(f => commandFiles.push(`./${manifest.commands}/ensemble/${f}`));
+        } else {
+          // Use flat structure
+          fs.readdirSync(commandsDir)
+            .filter(f => f.endsWith('.md'))
+            .forEach(f => commandFiles.push(`./${manifest.commands}/${f}`));
+        }
+      }
+      
+      manifest.commands = commandFiles;
+      console.log(`  ✓ Fixed commands: ${commandFiles.length} files`);
+      modified = true;
+    }
+    
+    // Fix skills
+    if (typeof manifest.skills === 'string') {
+      const skillsDir = path.join(packageDir, manifest.skills);
+      if (fs.existsSync(skillsDir)) {
+        const skillDirs = fs.readdirSync(skillsDir)
+          .filter(f => {
+            const fullPath = path.join(skillsDir, f);
+            return fs.statSync(fullPath).isDirectory();
+          })
+          .map(d => `./${manifest.skills}/${d}`);
+        
+        if (skillDirs.length > 0) {
+          manifest.skills = skillDirs;
+          console.log(`  ✓ Fixed skills: ${skillDirs.length} directories`);
+          modified = true;
+        } else {
+          manifest.skills = [];
+          console.log(`  ✓ Fixed skills: empty array (no directories found)`);
+          modified = true;
+        }
+      } else {
+        manifest.skills = [];
+        console.log(`  ✓ Fixed skills: empty array (directory not found)`);
+        modified = true;
+      }
+    }
+    
+    if (modified) {
+      // Write back with proper formatting
+      fs.writeFileSync(
+        manifestPath,
+        JSON.stringify(manifest, null, 2) + '\n',
+        'utf8'
+      );
+      console.log(`  ✓ Saved: ${manifestPath}\n`);
+      fixed++;
+    } else {
+      console.log(`  - Already in array format, skipped\n`);
+      skipped++;
+    }
+    
+  } catch (error) {
+    console.error(`  ✗ Error processing ${manifestPath}: ${error.message}\n`);
+    errors++;
+  }
+}
+
+console.log('=====================================');
+console.log(`Summary:`);
+console.log(`  Fixed:   ${fixed}`);
+console.log(`  Skipped: ${skipped}`);
+console.log(`  Errors:  ${errors}`);
+console.log(`  Total:   ${pluginManifests.length}`);
+console.log('=====================================');
+
+if (fixed > 0) {
+  console.log('\nRun `claude plugin validate packages/<package-name>` to verify fixes');
+}
+
+process.exit(errors > 0 ? 1 : 0);


### PR DESCRIPTION
## Problem
Current plugin manifests use directory string format which fails validation in Claude's plugin system:
```json
"agents": "./agents"
```

Error: `agents: Invalid input: must end with ".md"`

## Solution
Convert all plugin manifests to use explicit arrays:
```json
"agents": ["./agents/file1.md", "./agents/file2.md", ...]
```

## Changes
- Updates all 21 plugin manifests to use array format
- Adds `scripts/fix-plugin-manifests.js` for automated conversion
- Adds `npm run fix-manifests` script to package.json

## Testing
```bash
# Validation now passes
claude plugin validate packages/core
✔ Validation passed

# Installation now works
claude plugin install ensemble-core
✔ Successfully installed plugin: ensemble-core@ensemble
```

## Impact
- Fixes plugin installation from marketplace
- Enables proper plugin lifecycle management (install/update/uninstall)
- No breaking changes to plugin functionality