### PR TITLE
fix(full): expose router hooks from ensemble-full plugin

### DIFF
--- a/packages/full/hooks/hooks.json
+++ b/packages/full/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/router.py",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Task",

--- a/packages/full/hooks/router.py
+++ b/packages/full/hooks/router.py
@@ -1,0 +1,1 @@
+../../router/hooks/router.py

--- a/packages/full/lib/router-rules.json
+++ b/packages/full/lib/router-rules.json
@@ -1,0 +1,1 @@
+../../router/lib/router-rules.json


### PR DESCRIPTION
## Summary
- Fix router package's UserPromptSubmit hook not being registered when using ensemble-full
- Add hooks directory with symlinks to router package's hook script and rules
- Add "hooks" field to ensemble-full plugin.json

## Problem
The router hook was correctly configured in `packages/router/` but wasn't being discovered by Claude Code because `ensemble-full` didn't expose it in its plugin.json. Only plugins that are directly installed (not peer dependencies) have their hooks registered.

## Solution
- Created `packages/full/hooks/hooks.json` with UserPromptSubmit configuration
- Symlinked `hooks/router.py` → `../../router/hooks/router.py`
- Symlinked `lib/router-rules.json` → `../../router/lib/router-rules.json`
- Added `"hooks": "./hooks/hooks.json"` to plugin.json

The symlinks become absolute paths when the plugin is installed, allowing router.py to correctly resolve its `../lib/router-rules.json` dependency.

## Test plan
- [ ] Uninstall and reinstall ensemble-full plugin
- [ ] Start new Claude Code session
- [ ] Verify router hook fires on prompt submission (use `ROUTER_DEBUG=1 claude` to see output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)