### PR TITLE
fix(full): expose router commands from ensemble-full plugin

### DIFF
--- a/packages/full/.claude-plugin/plugin.json
+++ b/packages/full/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
     "./commands/git",
     "./commands/e2e-testing",
     "./commands/metrics",
+    "./commands/router",
     "./commands/agent-progress-pane",
     "./commands/task-progress-pane"
   ],

--- a/packages/full/commands/router
+++ b/packages/full/commands/router
@@ -1,0 +1,1 @@
+../../router/commands


### PR DESCRIPTION
## Summary
- Add symlink `packages/full/commands/router` → `../../router/commands`
- Add `"./commands/router"` to plugin.json commands array

This exposes the router commands when installing `ensemble-full`:
- `/ensemble-full:generate-project-router-rules`
- `/ensemble-full:generate-router-rules`

## Test plan
- [ ] Install `ensemble-full@ensemble` plugin
- [ ] Verify router commands appear in `/help` or command list
- [ ] Run `/ensemble-full:generate-router-rules` to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)