### PR TITLE
fix(full): add missing router commands symlink

### DIFF
--- a/packages/full/.claude-plugin/plugin.json
+++ b/packages/full/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
     "./commands/git",
     "./commands/e2e-testing",
     "./commands/metrics",
+    "./commands/router",
     "./commands/agent-progress-pane",
     "./commands/task-progress-pane"
   ],

--- a/packages/full/commands/router
+++ b/packages/full/commands/router
@@ -1,0 +1,1 @@
+../../router/commands


### PR DESCRIPTION
## Summary

- Adds missing `router-commands` symlink to the ensemble-full package
- The router hook was working but the router commands (`generate-project-router-rules`, `generate-router-rules`) were not exposed from ensemble-full

This is a minor hotfix to ensure router commands are accessible when using ensemble-full.

## Test plan

- [ ] Verify `router-commands` symlink exists in `packages/full/.claude-plugin/`
- [ ] Confirm router commands are visible when ensemble-full plugin is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)