### PR TITLE
hotfix(router): add ensemble namespace prefix to command names

### DIFF
--- a/packages/router/commands/generate-project-router-rules.md
+++ b/packages/router/commands/generate-project-router-rules.md
@@ -1,5 +1,5 @@
 ---
-name: generate-project-router-rules
+name: ensemble:generate-project-router-rules
 description: Generate project-specific router rules by analyzing the project's tech stack
 allowed-tools: Read, Write, Grep, Glob
 ---

--- a/packages/router/commands/generate-router-rules.md
+++ b/packages/router/commands/generate-router-rules.md
@@ -1,5 +1,5 @@
 ---
-name: generate-router-rules
+name: ensemble:generate-router-rules
 description: Generate router rules by introspecting installed agents and skills
 allowed-tools: Read, Write, Grep, Glob
 ---


### PR DESCRIPTION
## Summary

- Adds the `ensemble:` namespace prefix to router commands for consistency with other ensemble commands
- Fixes command discoverability by aligning with the naming convention used by all other ensemble commands (e.g., `ensemble:create-prd`, `ensemble:implement-trd`)

## Changes

- `packages/router/commands/generate-project-router-rules.md` - renamed from `generate-project-router-rules` to `ensemble:generate-project-router-rules`
- `packages/router/commands/generate-router-rules.md` - renamed from `generate-router-rules` to `ensemble:generate-router-rules`

## Test plan

- [ ] Verify commands are discoverable with the `ensemble:` prefix
- [ ] Confirm router functionality works with namespaced command names
- [ ] Validate no regression in existing router behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)