### PR TITLE
Fix WezTerm pane keyboard input not responding

### DIFF
--- a/packages/agent-progress-pane/hooks/agent-monitor.sh
+++ b/packages/agent-progress-pane/hooks/agent-monitor.sh
@@ -239,7 +239,9 @@ handle_input() {
     local key
 
     # Read with 100ms timeout, single character, silent
-    if read -t 0.1 -n 1 -s key 2>/dev/null; then
+    # Read from /dev/tty to ensure input comes from the terminal device,
+    # not stdin (which may be a pipe when spawned by WezTerm split-pane)
+    if read -t 0.1 -n 1 -s key < /dev/tty 2>/dev/null; then
         case "$key" in
             e|$'\n')  # e or Enter
                 toggle_expand
@@ -250,7 +252,7 @@ handle_input() {
             j|$'\x1b')  # j or escape sequence start (arrow keys)
                 # Handle arrow keys
                 if [[ "$key" == $'\x1b' ]]; then
-                    read -t 0.01 -n 2 -s arrow 2>/dev/null
+                    read -t 0.01 -n 2 -s arrow < /dev/tty 2>/dev/null
                     if [[ "$arrow" == "[B" ]]; then  # Down arrow
                         navigate_down
                     elif [[ "$arrow" == "[A" ]]; then  # Up arrow
@@ -489,7 +491,7 @@ if [ "$AUTO_CLOSE_TIMEOUT" -gt 0 ] 2>/dev/null; then
     countdown=$AUTO_CLOSE_TIMEOUT
     while [ $countdown -gt 0 ]; do
         # Check for keypress with 1 second timeout
-        if read -t 1 -n 1 -s 2>/dev/null; then
+        if read -t 1 -n 1 -s < /dev/tty 2>/dev/null; then
             break  # User pressed a key
         fi
         countdown=$((countdown - 1))
@@ -502,5 +504,5 @@ if [ "$AUTO_CLOSE_TIMEOUT" -gt 0 ] 2>/dev/null; then
 else
     # Manual close (original behavior)
     echo -e "${DIM}Press any key to close...${RESET}"
-    read -n 1 -s
+    read -n 1 -s < /dev/tty
 fi

--- a/packages/full/hooks/agent-monitor.sh
+++ b/packages/full/hooks/agent-monitor.sh
@@ -239,7 +239,9 @@ handle_input() {
     local key
 
     # Read with 100ms timeout, single character, silent
-    if read -t 0.1 -n 1 -s key 2>/dev/null; then
+    # Read from /dev/tty to ensure input comes from the terminal device,
+    # not stdin (which may be a pipe when spawned by WezTerm split-pane)
+    if read -t 0.1 -n 1 -s key < /dev/tty 2>/dev/null; then
         case "$key" in
             e|$'\n')  # e or Enter
                 toggle_expand
@@ -250,7 +252,7 @@ handle_input() {
             j|$'\x1b')  # j or escape sequence start (arrow keys)
                 # Handle arrow keys
                 if [[ "$key" == $'\x1b' ]]; then
-                    read -t 0.01 -n 2 -s arrow 2>/dev/null
+                    read -t 0.01 -n 2 -s arrow < /dev/tty 2>/dev/null
                     if [[ "$arrow" == "[B" ]]; then  # Down arrow
                         navigate_down
                     elif [[ "$arrow" == "[A" ]]; then  # Up arrow
@@ -489,7 +491,7 @@ if [ "$AUTO_CLOSE_TIMEOUT" -gt 0 ] 2>/dev/null; then
     countdown=$AUTO_CLOSE_TIMEOUT
     while [ $countdown -gt 0 ]; do
         # Check for keypress with 1 second timeout
-        if read -t 1 -n 1 -s 2>/dev/null; then
+        if read -t 1 -n 1 -s < /dev/tty 2>/dev/null; then
             break  # User pressed a key
         fi
         countdown=$((countdown - 1))
@@ -502,5 +504,5 @@ if [ "$AUTO_CLOSE_TIMEOUT" -gt 0 ] 2>/dev/null; then
 else
     # Manual close (original behavior)
     echo -e "${DIM}Press any key to close...${RESET}"
-    read -n 1 -s
+    read -n 1 -s < /dev/tty
 fi

--- a/packages/full/hooks/task-progress-monitor-v2.sh
+++ b/packages/full/hooks/task-progress-monitor-v2.sh
@@ -121,7 +121,9 @@ while true; do
     render
     
     # Non-blocking key read
-    if read -t 1 -n 1 key 2>/dev/null; then
+    # Read from /dev/tty to ensure input comes from the terminal device,
+    # not stdin (which may be a pipe when spawned by WezTerm split-pane)
+    if read -t 1 -n 1 key < /dev/tty 2>/dev/null; then
         [[ "$key" == "q" ]] && exit 0
     fi
 done

--- a/packages/task-progress-pane/hooks/task-progress-monitor-v2.sh
+++ b/packages/task-progress-pane/hooks/task-progress-monitor-v2.sh
@@ -121,7 +121,9 @@ while true; do
     render
     
     # Non-blocking key read
-    if read -t 1 -n 1 key 2>/dev/null; then
+    # Read from /dev/tty to ensure input comes from the terminal device,
+    # not stdin (which may be a pipe when spawned by WezTerm split-pane)
+    if read -t 1 -n 1 key < /dev/tty 2>/dev/null; then
         [[ "$key" == "q" ]] && exit 0
     fi
 done


### PR DESCRIPTION
## Problem

The WezTerm subagent monitor pane displays keystrokes but doesn't respond to keyboard commands (`q`, `e`, `a`, `j`/`k`, arrow keys).

**Root cause:** When WezTerm spawns a pane via `wezterm cli split-pane`, the child process stdin is connected to a pipe from the Node.js `spawnSync` call (`stdio: ['pipe', 'pipe', 'pipe']`) rather than the terminal PTY. The bash `read` commands read from this empty pipe, so the 100ms timeout always expires without capturing any input. Keystrokes appear on screen because the terminal itself echoes them, but the script never sees them.

## Solution

Redirect all `read` calls in the monitor scripts to `/dev/tty`, which always refers to the controlling terminal device regardless of how stdin was set up. This is the standard approach for reading user input in scripts that may have redirected stdin.

## Changes

- `packages/agent-progress-pane/hooks/agent-monitor.sh`: 4 `read` calls redirected to `/dev/tty` (main input loop, arrow key sequence, auto-close countdown, manual close)
- `packages/task-progress-pane/hooks/task-progress-monitor-v2.sh`: 1 `read` call redirected to `/dev/tty`
- `packages/full/hooks/`: Synced copies updated via `npm run sync-hooks`

## Test Plan

- [x] `npm test --workspace=packages/agent-progress-pane` passes (247/278, pre-existing Zellij test skip)
- [x] `npm test --workspace=packages/task-progress-pane` passes (55/55)
- [x] ensemble-full hooks synced (24 files)
- [ ] Manual verification: spawn a subagent in WezTerm and confirm `q`/`e`/`a`/`j`/`k` keys work

🤖 Generated with [Claude Code](https://claude.com/claude-code)