### PR TITLE
Add .sidecar/ and .todos/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Local tool state
+.sidecar/
+.todos/
+


### PR DESCRIPTION
## Summary

- Add `.sidecar/` and `.todos/` to `.gitignore` to prevent local tool state from being tracked

These directories contain ephemeral local data (sidecar shell sessions, todo database files) that are machine-specific and should not be committed.

## Test plan

- [x] Verify `.gitignore` syntax is valid
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)