### PR TITLE
Pass signalFile to getPaneInfo in task-pane-manager

### DIFF
--- a/packages/full/lib/task-pane-manager.js
+++ b/packages/full/lib/task-pane-manager.js
@@ -77,7 +77,9 @@ class TaskPaneManager {
 
     // Check if existing pane is still valid
     if (this.paneId) {
-      const info = await this.adapter.getPaneInfo(this.paneId);
+      const info = await this.adapter.getPaneInfo(this.paneId, {
+        signalFile: this.signalFile
+      });
       if (info) {
         return this.paneId;
       }
@@ -212,7 +214,9 @@ class TaskPaneManager {
       return false;
     }
 
-    const info = await this.adapter.getPaneInfo(this.paneId);
+    const info = await this.adapter.getPaneInfo(this.paneId, {
+      signalFile: this.signalFile
+    });
     return info !== null;
   }
 


### PR DESCRIPTION
## Summary

- Pass `signalFile` option to `getPaneInfo()` calls in `packages/full/lib/task-pane-manager.js`

## Problem

The `getPaneInfo()` calls were missing the `signalFile` context, preventing the adapter from checking pane liveness accurately using the signal file state.

## Changes

- `packages/full/lib/task-pane-manager.js`: 2 call sites updated to pass `{ signalFile: this.signalFile }`

## Test plan

- [x] No test regressions
- [ ] Manual verification: task pane lifecycle works correctly with signal file checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)