### PR TITLE
fix(tests): fix version assertion and ask-user TS type error

### DIFF
--- a/packages/development/tests/auto-team-trd-parser.test.js
+++ b/packages/development/tests/auto-team-trd-parser.test.js
@@ -430,8 +430,8 @@ describe('TRD-041: implement-trd-beads.yaml structure', () => {
     expect(rawContent.length).toBeGreaterThan(0);
   });
 
-  it('version is 2.12.0', () => {
-    expect(rawContent).toMatch(/version:\s*['"]?2\.12\.0['"]?/);
+  it('version is 2.13.0', () => {
+    expect(rawContent).toMatch(/version:\s*['"]?2\.13\.0['"]?/);
   });
 
   it('preflight step 8 contains TRD-first parsing logic', () => {

--- a/packages/pi/extensions/ask-user.ts
+++ b/packages/pi/extensions/ask-user.ts
@@ -27,14 +27,10 @@ export default function (pi: ExtensionAPI): void {
     description:
       'Ask the user a single question and return their answer. Use for interactive interviews — one question at a time.',
     parameters: {
-      type: 'object',
-      properties: {
-        question: {
-          type: 'string',
-          description: 'The question to display to the user',
-        },
+      question: {
+        type: 'string',
+        description: 'The question to display to the user',
       },
-      required: ['question'],
     },
     execute: async ({ question }: ToolParameters): Promise<string> => {
       try {


### PR DESCRIPTION
## Summary

- Update version assertion in `auto-team-trd-parser.test.js` from `2.12.0` → `2.13.0` to match the current `implement-trd-beads.yaml` metadata version
- Fix `TS2322` type error in `packages/pi/extensions/ask-user.ts` — flatten the `parameters` object from a JSON Schema shape to the flat `Record<string, { type: string; description: string }>` required by `ExtensionAPI.parameters`

## Root Cause

Two pre-existing failures surfaced after `0dbcb75`:
1. `implement-trd-beads.yaml` was bumped to `v2.13.0` but the test pinned `2.12.0`
2. `ask-user.ts` used a JSON Schema object structure that doesn't match the `ExtensionAPI.parameters` type

## Test plan

- [ ] `tests/auto-team-trd-parser.test.js` passes version assertion
- [ ] `tests/ask-user.test.ts` compiles without TS2322
- [ ] All other tests unaffected (only 2 files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)