### PR TITLE
fix(generator): resolve tier alias model: fields in generated command frontmatter

### DIFF
--- a/.claude/ensemble-model-config.json
+++ b/.claude/ensemble-model-config.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "tiers": {
+    "high": "claude-opus-4-7",
+    "medium": "claude-sonnet-4-6",
+    "low": "claude-haiku-4-5-20251001"
+  },
+  "extraKnownModelIds": []
+}

--- a/packages/codex/.codex/skills/commands/ensemble-analyze-requirements/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-analyze-requirements/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-analyze-requirements
 description: Pre-implementation cross-artifact consistency sweep — checks PRD↔TRD↔beads alignment before coding begins (Codex skill for /ensemble:analyze-requirements)
 user-invocable: true
 argument-hint: '[prd-path] [trd-path]'
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:analyze-requirements

--- a/packages/codex/.codex/skills/commands/ensemble-beads-build/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-beads-build/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-beads-build
 description: Drive an existing bead hierarchy to completion through the full builder, code-review, and close pipeline (Codex skill for /ensemble:beads-build)
 user-invocable: true
 argument-hint: '[epic-id|slug-pattern] [--trd trd-path] [--strategy tdd|characterization|bug-fix|refactor|test-after|flexible] [max parallel N]'
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:beads-build

--- a/packages/codex/.codex/skills/commands/ensemble-beads-plan/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-beads-plan/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-beads-plan
 description: Analyze an existing bead hierarchy and produce bv analysis and wheel instructions without executing any implementation (Codex skill for /ensemble:beads-plan)
 user-invocable: true
 argument-hint: '[epic-id|slug-pattern] [max parallel N]'
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:beads-plan

--- a/packages/codex/.codex/skills/commands/ensemble-configure-team/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-configure-team/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-configure-team
 description: Analyze TRD complexity and auto-configure team roles, agent assignments, and marketplace plugins (Codex skill for /ensemble:configure-team)
 user-invocable: true
 argument-hint: '[trd-path] [--team] [--no-team]'
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:configure-team

--- a/packages/codex/.codex/skills/commands/ensemble-create-prd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-create-prd/SKILL.md
@@ -2,7 +2,7 @@
 name: ensemble-create-prd
 description: Create comprehensive Product Requirements Document with structured elicitation and adversarial review (Codex skill for /ensemble:create-prd)
 user-invocable: true
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:create-prd

--- a/packages/codex/.codex/skills/commands/ensemble-create-trd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-create-trd/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-create-trd
 description: Create Technical Requirements Document from PRD with architecture design and adversarial review (Codex skill for /ensemble:create-trd)
 user-invocable: true
 argument-hint: '[prd-path] [--team]'
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:create-trd

--- a/packages/codex/.codex/skills/commands/ensemble-discover-standards/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-discover-standards/SKILL.md
@@ -4,7 +4,7 @@ description: Analyze codebase and extract coding conventions into a standards/ d
 user-invocable: true
 argument-hint:
   - path
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:discover-standards

--- a/packages/codex/.codex/skills/commands/ensemble-feature/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-feature/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-feature
 description: 'Orchestrate the full idea-to-plan pipeline: create-prd, refine-prd, create-trd, refine-trd, implement-trd-beads --plan (Codex skill for /ensemble:feature)'
 user-invocable: true
 argument-hint: <description> [--skip-refine]
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:feature

--- a/packages/codex/.codex/skills/commands/ensemble-fix-issue/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-fix-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: ensemble-fix-issue
 description: Lightweight workflow for bug fixes and small issues (Codex skill for /ensemble:fix-issue)
 user-invocable: true
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:fix-issue

--- a/packages/codex/.codex/skills/commands/ensemble-implement-bead/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-implement-bead/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-implement-bead
 description: Implement a single beads task by ID through analysis, implementation, and PR creation (Codex skill for /ensemble:implement-bead)
 user-invocable: true
 argument-hint: <bead-id>
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:implement-bead

--- a/packages/codex/.codex/skills/commands/ensemble-implement-trd-beads/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-implement-trd-beads/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-implement-trd-beads
 description: Implement TRD with beads project management — persistent bead hierarchy, dependency-aware execution via br/bv, and cross-session resumability (Codex skill for /ensemble:implement-trd-beads)
 user-invocable: true
 argument-hint: '[trd-path] [--plan] [--execute] [--status] [--reset-task TRD-XXX] [max parallel N]'
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:implement-trd-beads

--- a/packages/codex/.codex/skills/commands/ensemble-implement-trd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-implement-trd/SKILL.md
@@ -2,7 +2,7 @@
 name: ensemble-implement-trd
 description: Complete TRD implementation using git-town workflow with ensemble-orchestrator delegation and TDD methodology (Codex skill for /ensemble:implement-trd)
 user-invocable: true
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:implement-trd

--- a/packages/codex/.codex/skills/commands/ensemble-inject-standards/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-inject-standards/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-inject-standards
 description: Selectively inject relevant standards from standards/index.yml into agent context based on current task (Codex skill for /ensemble:inject-standards)
 user-invocable: true
 argument-hint: <task-description>
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:inject-standards

--- a/packages/codex/.codex/skills/commands/ensemble-refine-prd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-refine-prd/SKILL.md
@@ -2,7 +2,7 @@
 name: ensemble-refine-prd
 description: Refine and enhance existing PRD with stakeholder feedback and additional detail (Codex skill for /ensemble:refine-prd)
 user-invocable: true
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:refine-prd

--- a/packages/codex/.codex/skills/commands/ensemble-refine-trd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-refine-trd/SKILL.md
@@ -2,7 +2,7 @@
 name: ensemble-refine-trd
 description: Refine and enhance existing TRD with stakeholder feedback and additional detail (Codex skill for /ensemble:refine-trd)
 user-invocable: true
-model: high
+model: claude-opus-4-7
 ---
 
 # Ensemble Command: /ensemble:refine-trd

--- a/packages/codex/.codex/skills/commands/ensemble-requirement-status/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-requirement-status/SKILL.md
@@ -4,7 +4,7 @@ description: On-demand requirement satisfaction report — scans bead comments f
 user-invocable: true
 argument-hint:
   - trd-path-or-slug
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:requirement-status

--- a/packages/codex/.codex/skills/commands/ensemble-validate-requirements/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-validate-requirements/SKILL.md
@@ -3,7 +3,7 @@ name: ensemble-validate-requirements
 description: Pre-implementation traceability gate — validates REQ-NNN coverage and TEST task pairing between PRD and TRD (Codex skill for /ensemble:validate-requirements)
 user-invocable: true
 argument-hint: '[prd-path] [trd-path]'
-model: medium
+model: claude-sonnet-4-6
 ---
 
 # Ensemble Command: /ensemble:validate-requirements

--- a/packages/core/commands/ensemble/discover-standards.md
+++ b/packages/core/commands/ensemble/discover-standards.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: analysis
 last-updated: 2026-03-29
 argument-hint: [path]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from discover-standards.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/core/commands/ensemble/inject-standards.md
+++ b/packages/core/commands/ensemble/inject-standards.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: implementation
 last-updated: 2026-03-29
 argument-hint: <task-description>
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from inject-standards.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/analyze-requirements.md
+++ b/packages/development/commands/ensemble/analyze-requirements.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: planning
 last-updated: 2026-03-29
 argument-hint: [prd-path] [trd-path]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from analyze-requirements.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/beads-build.md
+++ b/packages/development/commands/ensemble/beads-build.md
@@ -6,7 +6,7 @@ category: implementation
 last-updated: 2026-03-29
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: [epic-id|slug-pattern] [--trd trd-path] [--strategy tdd|characterization|bug-fix|refactor|test-after|flexible] [max parallel N]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from beads-build.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/beads-plan.md
+++ b/packages/development/commands/ensemble/beads-plan.md
@@ -6,7 +6,7 @@ category: implementation
 last-updated: 2026-03-29
 allowed-tools: Read, Bash, Grep, Glob
 argument-hint: [epic-id|slug-pattern] [max parallel N]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from beads-plan.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/configure-team.md
+++ b/packages/development/commands/ensemble/configure-team.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: planning
 last-updated: 2026-03-28
 argument-hint: [trd-path] [--team] [--no-team]
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from configure-team.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/create-trd.md
+++ b/packages/development/commands/ensemble/create-trd.md
@@ -5,7 +5,7 @@ version: 3.1.0
 category: planning
 last-updated: 2026-05-30
 argument-hint: [prd-path] [--team]
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from create-trd.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/fix-issue.md
+++ b/packages/development/commands/ensemble/fix-issue.md
@@ -4,7 +4,7 @@ description: Lightweight workflow for bug fixes and small issues
 version: 1.1.0
 category: implementation
 last-updated: 2026-03-29
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from fix-issue.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/implement-bead.md
+++ b/packages/development/commands/ensemble/implement-bead.md
@@ -6,7 +6,7 @@ category: implementation
 last-updated: 2026-03-29
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: <bead-id>
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from implement-bead.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/implement-trd-beads.md
+++ b/packages/development/commands/ensemble/implement-trd-beads.md
@@ -6,7 +6,7 @@ category: implementation
 last-updated: 2026-05-30
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: [trd-path] [--plan] [--execute] [--status] [--reset-task TRD-XXX] [max parallel N]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from implement-trd-beads.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/implement-trd.md
+++ b/packages/development/commands/ensemble/implement-trd.md
@@ -4,7 +4,7 @@ description: Complete TRD implementation using git-town workflow with ensemble-o
 version: 2.1.0
 category: implementation
 last-updated: 2026-05-27
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from implement-trd.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/refine-trd.md
+++ b/packages/development/commands/ensemble/refine-trd.md
@@ -4,7 +4,7 @@ description: Refine and enhance existing TRD with stakeholder feedback and addit
 version: 2.4.0
 category: planning
 last-updated: 2026-05-30
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from refine-trd.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/requirement-status.md
+++ b/packages/development/commands/ensemble/requirement-status.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: implementation
 last-updated: 2026-03-15
 argument-hint: [trd-path-or-slug]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from requirement-status.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/development/commands/ensemble/validate-requirements.md
+++ b/packages/development/commands/ensemble/validate-requirements.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: planning
 last-updated: 2026-03-15
 argument-hint: [prd-path] [trd-path]
-model: medium
+model: claude-sonnet-4-6
 ---
 <!-- DO NOT EDIT - Generated from validate-requirements.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/product/commands/ensemble/create-prd.md
+++ b/packages/product/commands/ensemble/create-prd.md
@@ -4,7 +4,7 @@ description: Create comprehensive Product Requirements Document with structured 
 version: 2.4.0
 category: planning
 last-updated: 2026-03-29
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from create-prd.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/product/commands/ensemble/feature.md
+++ b/packages/product/commands/ensemble/feature.md
@@ -5,7 +5,7 @@ version: 1.0.0
 category: planning
 last-updated: 2026-03-15
 argument-hint: <description> [--skip-refine]
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from feature.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/packages/product/commands/ensemble/refine-prd.md
+++ b/packages/product/commands/ensemble/refine-prd.md
@@ -4,7 +4,7 @@ description: Refine and enhance existing PRD with stakeholder feedback and addit
 version: 2.4.0
 category: planning
 last-updated: 2026-03-29
-model: high
+model: claude-opus-4-7
 ---
 <!-- DO NOT EDIT - Generated from refine-prd.yaml -->
 <!-- To modify this file, edit the YAML source and run: npm run generate -->

--- a/scripts/lib/command-transformer.js
+++ b/scripts/lib/command-transformer.js
@@ -5,6 +5,10 @@
 
 'use strict';
 
+// NOTE: model: tier aliases in source YAML are resolved to fully-pinned model IDs
+// at generation time via packages/core/lib/config-loader + model-resolver.
+// Generated .md files always contain real model IDs (or no model: field if unresolvable).
+
 const path = require('path');
 
 /**
@@ -63,9 +67,25 @@ function generateCommandFrontmatter(data) {
     lines.push(`argument-hint: ${meta.argument_hint}`);
   }
 
-  // Model (optional)
+  // Resolve tier aliases to fully-pinned model IDs before emitting.
+  // Claude Code rejects tier names ('high', 'medium', 'low') as model IDs.
+  // If resolution fails, suppress the field so Claude Code uses the user's default.
   if (meta.model) {
-    lines.push(`model: ${meta.model}`);
+    const TIER_ALIASES = new Set(['high', 'medium', 'low']);
+    let resolvedModel = meta.model;
+    if (TIER_ALIASES.has(meta.model)) {
+      try {
+        const { loadConfig } = require('../../packages/core/lib/config-loader');
+        const { resolveModel } = require('../../packages/core/lib/model-resolver');
+        const cfg = loadConfig(process.cwd());
+        resolvedModel = resolveModel(meta.model, cfg);
+      } catch (_) {
+        resolvedModel = null; // suppress on any error
+      }
+    }
+    if (resolvedModel) {
+      lines.push(`model: ${resolvedModel}`);
+    }
   }
 
   lines.push('---');


### PR DESCRIPTION
## Summary

- **Root cause:** `command-transformer.js` emitted tier aliases (`high`, `medium`, `low`) verbatim into generated `.md` frontmatter. Claude Code reads the `model:` field and rejects tier names as invalid model IDs, crashing every command with "invalid model medium/high".
- **Fix:** Generator now resolves tier aliases to fully-pinned model IDs via `config-loader` + `model-resolver` at generation time (e.g. `high → claude-opus-4-7`). If resolution fails (no config, Bedrock, etc.) the field is suppressed entirely so Claude Code falls back to the user's default model — no crash.
- **35 generated files** updated: all command `.md` and Codex SKILL files now contain real model IDs.
- `.claude/ensemble-model-config.json` added to repo (pins standard Anthropic tier defaults).

## Test plan

- [ ] `npm run generate` produces no new errors (5 pre-existing YAML schema errors unaffected)
- [ ] `npm run validate` exits 0
- [ ] `grep "^model: high\|^model: medium\|^model: low" packages/*/commands/ensemble/*.md` returns no matches
- [ ] `grep "^model:" packages/development/commands/ensemble/create-trd.md` returns `model: claude-opus-4-7`
- [ ] Running any ensemble command (e.g. `/ensemble:implement-trd-beads`) no longer errors with "invalid model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)