### PR TITLE
feat(development): TRD staleness gate — prevent implementation against stale TRDs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,10 @@
       "Bash(python3 -c \":*)",
       "WebFetch(domain:github.com)",
       "Bash(node -e \"const d=JSON.parse\\(require\\(''''fs''''\\).readFileSync\\(''''/dev/stdin'''',''''utf8''''\\)\\); console.log\\(''''desc:'''', d.description\\); console.log\\(''''readme:'''', \\(d.readme||''''''''\\).slice\\(0,2000\\)\\)\")",
-      "Bash(bv --help)"
+      "Bash(bv --help)",
+      "Bash(git town *)",
+      "Bash(br list *)",
+      "Bash(python3 -c ' *)"
     ]
   },
   "enabledPlugins": {}

--- a/docs/PRD/PRD-2026-022-trd-staleness-gate.md
+++ b/docs/PRD/PRD-2026-022-trd-staleness-gate.md
@@ -1,0 +1,175 @@
+---
+document_id: PRD-2026-022
+version: 1.0.0
+status: Draft
+date: 2026-06-01
+scale_depth: LIGHT
+total_requirements: 8
+readiness_score: 4.75
+---
+
+# PRD-2026-022: TRD Staleness Gate
+
+## PRD Health Summary
+
+| Metric | Value |
+|--------|-------|
+| Must requirements | 7 |
+| Should requirements | 1 |
+| Could requirements | 0 |
+| Won't requirements | 0 |
+| AC coverage | 8/8 (100%) |
+| Risk flags | 1 |
+| Cross-requirement dependencies | 4 |
+
+## Product Summary
+
+**Problem:** Developers and AI agents invoke `implement-trd` (and its flavors) against TRD files that have grown stale — either because time has passed since the TRD was last reviewed, or because source files have changed in ways that affect requirements. The result is implementation work built on outdated specifications.
+
+**Solution:** A mandatory staleness gate added to the Preflight phase of all `implement-trd` flavors. On first invocation, the gate checks two conditions: TRD age > 24 hours, and whether any source file in the worktree is newer than the TRD. If either condition is true, `refine-trd` runs automatically before implementation begins. If refinement fails, the command halts with a hard stop.
+
+**Value proposition:** No implementation ever starts against a stale TRD.
+
+**Target users:** Developers and AI agents running `implement-trd`, `implement-trd-beads`, or `beads-build --trd`.
+
+**Known limitation:** `git clone`, `git checkout`, and `git pull` reset all file mtimes to the current time. A freshly-cloned repo where the TRD content is months old will appear "fresh" to the mtime-based check. This is a best-effort guard for ongoing work; it cannot detect staleness introduced by checking out an old branch in a fresh environment.
+
+## Goals and Non-Goals
+
+**Goals:**
+- Prevent implementation from starting against any TRD older than 24 hours
+- Prevent implementation from starting when source files have changed since the TRD was last updated
+- Apply consistently across all three `implement-trd` flavors
+- Hard-stop (no bypass flag) — enforcement is mandatory
+
+**Non-Goals:**
+- Content-aware staleness detection (semantic diff of TRD vs codebase)
+- Configurable age thresholds (24h is hardcoded in this release)
+- Detection of staleness introduced by fresh git clone/checkout (known limitation)
+- Bypass or skip flag
+
+---
+
+## Requirements
+
+### Staleness Detection
+
+#### REQ-001: Age-Based Staleness Detection
+**Priority:** Must | **Complexity:** Low
+
+The staleness gate triggers when the TRD file's last-modified time (mtime) is more than 24 hours before the current system time at the moment the command is invoked.
+
+- **AC-001-1:** Given a TRD file whose mtime is more than 24 hours before the current system time, when any `implement-trd` flavor is invoked on a first invocation, then the staleness gate triggers before any git operations or scaffold creation begins.
+- **AC-001-2:** Given a TRD file whose mtime is less than 24 hours old and no source files are newer than the TRD, when any `implement-trd` flavor is invoked, then the staleness gate does not trigger and implementation proceeds normally.
+
+#### REQ-002: Content-Drift Staleness Detection
+**Priority:** Must | **Complexity:** Medium | [RISK: exclusion list must be maintained as new generated paths are added]
+
+The staleness gate also triggers when any source file in the worktree has an mtime newer than the TRD file, even if the TRD itself is less than 24 hours old.
+
+"Source files" are determined by running `git ls-files` (tracked files) and filtering out:
+- All paths matching `.gitignore` patterns (covers `dist/`, `build/`, `node_modules/`, `coverage/`, `.beads.bd/`, `.bv/`, `.ntm/`, `.opencode/`, `.dolt/`, etc.)
+- `packages/*/commands/ensemble/` (generated markdown)
+- `packages/pi/prompts/` (generated pi prompts)
+- `packages/codex/.codex/` (generated codex skills)
+- Any path containing `/dist/` or `/build/` as a path segment
+
+- **AC-002-1:** Given a TRD file where one or more source files (after exclusion filtering) have mtime newer than the TRD mtime, when any `implement-trd` flavor is invoked fresh, then the staleness gate triggers even if the TRD itself is less than 24 hours old.
+- **AC-002-2:** Given the only files newer than the TRD are in `dist/`, `.beads.bd/`, `packages/*/commands/ensemble/`, `packages/pi/prompts/`, or `packages/codex/.codex/`, when any `implement-trd` flavor is invoked, then the staleness gate does NOT trigger.
+
+### Staleness Gate Behavior
+
+#### REQ-003: Auto-Invoke refine-trd on Stale Detection
+**Priority:** Must | **Complexity:** Medium
+
+When the staleness gate triggers on first invocation, the command halts its normal flow, prints a clear message identifying which condition was met, and automatically invokes `refine-trd` on the TRD file before proceeding.
+
+- **AC-003-1:** Given a stale TRD is detected (either condition), when the gate triggers, then the command prints a message stating the triggering condition (e.g., "TRD is 36 hours old — running refine-trd before implementation" or "3 source files are newer than the TRD: src/foo.ts, src/bar.ts, src/baz.ts — running refine-trd") and invokes `refine-trd` automatically.
+- **AC-003-2:** Given the staleness gate triggers, when the message is printed, then it lists up to 10 of the newer source files by path (if the drift condition was met) so the user understands what changed.
+
+#### REQ-004: Proceed After Successful Refinement
+**Priority:** Must | **Complexity:** Low
+
+If `refine-trd` completes successfully, the command proceeds to implementation from its normal starting point without re-running the staleness check.
+
+- **AC-004-1:** Given `refine-trd` exits successfully (exit code 0), when it finishes, then the `implement-trd` command continues from its first normal preflight step (git-town verification, TRD validation, etc.) as if freshly invoked — without re-running the staleness check.
+
+#### REQ-005: Hard Stop on Refinement Failure
+**Priority:** Must | **Complexity:** Low
+
+If `refine-trd` exits with an error or exception, the `implement-trd` command halts immediately. No implementation work begins. The user must fix the TRD manually and re-run.
+
+- **AC-005-1:** Given `refine-trd` exits with a non-zero exit code or throws an unhandled exception, when the error occurs, then the command prints "TRD refinement failed. Fix the TRD manually and re-run." and exits without creating any branches, beads, or implementation artifacts.
+
+#### REQ-006: Skip Staleness Check on Resume
+**Priority:** Must | **Complexity:** Low
+
+The staleness check runs only on first invocation. On resume, it is skipped entirely.
+
+Resume is detected as follows per flavor:
+- `implement-trd-beads`: existing root epic bead found (ROOT_EPIC_ID present in `br list`)
+- `implement-trd`: feature branch `feature/<TRD_SLUG>-sprint-1` already exists (`git branch --list` returns a match)
+- `beads-build --trd`: root epic for the TRD slug already exists in the beads store
+
+- **AC-006-1:** Given an existing bead scaffold (root epic present) is detected for `implement-trd-beads` or `beads-build --trd`, when the command is invoked, then the staleness gate step is skipped entirely and implementation resumes from the next appropriate step.
+- **AC-006-2:** Given the feature branch `feature/<TRD_SLUG>-sprint-1` already exists for `implement-trd`, when the command is invoked, then the staleness gate step is skipped and implementation resumes normally.
+
+### Coverage
+
+#### REQ-007: Apply Gate to All implement-trd Flavors
+**Priority:** Must | **Complexity:** Low
+
+The staleness gate is added to the Preflight phase of all three flavors: `implement-trd`, `implement-trd-beads`, and `beads-build` (when `--trd` flag is provided and `TRD_MODE=true`).
+
+- **AC-007-1:** Given `beads-build --trd <path>` is invoked with no existing root epic, when the command starts, then the staleness gate runs on the specified TRD before any scaffold is created.
+- **AC-007-2:** Given `beads-build --trd <path>` is invoked and a root epic for the TRD slug already exists, when the command starts, then the staleness gate step is skipped and implementation proceeds directly.
+
+### Observability
+
+#### REQ-008: Staleness Message Identifies Condition and Affected Files
+**Priority:** Should | **Complexity:** Low
+
+The staleness gate message clearly identifies which condition triggered (age vs. content drift) and, for content drift, lists the newer source files so the user understands what changed.
+
+- **AC-008-1:** Given the age condition triggered, when the message is printed, then it states the TRD age in hours (e.g., "TRD is 36h old, threshold is 24h").
+- **AC-008-2:** Given the content-drift condition triggered, when the message is printed, then it lists up to 10 newer source file paths and the total count if more than 10 exist (e.g., "14 source files are newer than the TRD. Showing first 10: ...").
+
+---
+
+## Acceptance Criteria Summary
+
+| REQ | Description | Priority | Complexity | AC Count |
+|-----|-------------|----------|------------|----------|
+| REQ-001 | Age-based staleness detection (>24h) | Must | Low | 2 |
+| REQ-002 | Content-drift staleness (newer source files) | Must | Medium | 2 |
+| REQ-003 | Auto-invoke refine-trd on stale detection | Must | Medium | 2 |
+| REQ-004 | Proceed after successful refinement | Must | Low | 1 |
+| REQ-005 | Hard stop on refinement failure | Must | Low | 1 |
+| REQ-006 | Skip staleness check on resume | Must | Low | 2 |
+| REQ-007 | Apply gate to all three flavors | Must | Low | 2 |
+| REQ-008 | Staleness message identifies condition + files | Should | Low | 2 |
+
+---
+
+## Dependency Map
+
+- REQ-003 depends on REQ-001 and REQ-002 (gate behavior requires detection to be defined)
+- REQ-004 depends on REQ-003 (success path follows auto-invocation)
+- REQ-005 depends on REQ-003 (failure path follows auto-invocation)
+- REQ-006 is a modifier on REQ-001/REQ-002/REQ-003 (resume skips all three)
+- REQ-007 depends on REQ-001 through REQ-006 (coverage is a cross-cutting concern)
+- REQ-008 depends on REQ-003 (message content is part of gate invocation)
+
+**Implementation cluster:** REQ-001 + REQ-002 + REQ-003 + REQ-006 must be implemented together as a single Preflight step in each command. REQ-004, REQ-005, and REQ-008 are additive to that step.
+
+---
+
+## Implementation Readiness Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Completeness | 5.0 | All 3 flavors, both staleness signals, resume, success/failure paths covered |
+| Testability | 4.5 | All Must ACs are Given/When/Then; exclusion list is explicitly enumerated |
+| Clarity | 4.5 | Preflight insertion point and resume detection signal specified per flavor |
+| Feasibility | 5.0 | Uses `git ls-files` + mtime — no new runtime dependencies |
+| **Overall** | **4.75** | **PASS — ready for TRD handoff** |

--- a/docs/TRD/TRD-2026-023-trd-staleness-gate.md
+++ b/docs/TRD/TRD-2026-023-trd-staleness-gate.md
@@ -1,10 +1,10 @@
 ---
 document_id: TRD-2026-023
 prd_reference: docs/PRD/PRD-2026-022-trd-staleness-gate.md
-version: 1.0.0
+version: 1.0.1
 status: Draft
 date: 2026-06-01
-design_readiness_score: 4.63
+design_readiness_score: 4.88
 ---
 
 # TRD-2026-023: TRD Staleness Gate
@@ -101,11 +101,12 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
 
 ## Master Task List
 
-### PR 1: Staleness Gate Skill
+### PR 1: TRD Staleness Gate
 
-**Shippable State:** The canonical staleness gate algorithm is documented in a standalone skill file that can be referenced by any command and manually applied; the algorithm itself is reviewable and testable in isolation.
+**Shippable State:** All three `implement-trd` flavors enforce the staleness gate on first invocation — no implementation starts against a TRD older than 24 hours or with newer source files; resume paths are unaffected.
 
-- [ ] **TRD-001**: Create `packages/development/skills/staleness-gate/SKILL.md` with the full staleness gate algorithm (2h) [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008]
+- [ ] **TRD-001**: Create `packages/development/skills/staleness-gate/SKILL.md` with the full staleness gate algorithm (3h) [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008]
+  - Validates PRD ACs: AC-001-1, AC-001-2, AC-002-1, AC-002-2, AC-003-1, AC-003-2, AC-004-1, AC-005-1, AC-008-1, AC-008-2
   - Target File: `packages/development/skills/staleness-gate/SKILL.md`
   - Actions:
     1. Create directory `packages/development/skills/staleness-gate/`
@@ -115,8 +116,8 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
        - **Step 1 — Resume Check**: if IS_RESUME=true → print "Staleness check: skipped (resume detected)" and RETURN
        - **Step 2 — Get TRD mtime**: `TRD_MTIME=$(stat -f %m "<TRD_PATH>")` (macOS) OR `TRD_MTIME=$(stat -c %Y "<TRD_PATH>")` (Linux) OR `python3 -c "import os; print(int(os.path.getmtime('<TRD_PATH>')))"` (fallback); on failure → print "WARNING: Cannot determine TRD file age — skipping staleness check." and RETURN
        - **Step 3 — Age Check**: `CURRENT_TIME=$(date +%s); AGE_SECONDS=$((CURRENT_TIME - TRD_MTIME)); AGE_HOURS=$((AGE_SECONDS / 3600)); if AGE_HOURS > 24 → STALE=true, STALE_REASON=age`
-       - **Step 4 — Source File Drift Check**: `git ls-files --exclude-standard | grep -vE "^packages/[^/]+/commands/ensemble/|^packages/pi/prompts/|^packages/codex/\.codex/"` → for each file get mtime → collect NEWER_FILES where file_mtime > TRD_MTIME; if NEWER_FILES non-empty and not already stale → STALE=true, STALE_REASON=drift
-       - **Step 5 — Gate Decision**: if STALE=false → print "Staleness check: TRD is current" and RETURN; if STALE=true and STALE_REASON=age → print "STALENESS GATE: TRD is ${AGE_HOURS}h old (threshold: 24h). Running /ensemble:refine-trd before implementation." and invoke `/ensemble:refine-trd <TRD_PATH>`; if STALE=true and STALE_REASON=drift → print "STALENESS GATE: ${NEWER_COUNT} source files are newer than the TRD." + list up to 10 file paths (show count if >10) + "Running /ensemble:refine-trd before implementation." and invoke `/ensemble:refine-trd <TRD_PATH>`
+       - **Step 4 — Source File Drift Check (always runs, even if age already triggered)**: `git ls-files --exclude-standard | grep -vE "^packages/[^/]+/commands/ensemble/|^packages/pi/prompts/|^packages/codex/\.codex/"` → for each file get mtime → collect NEWER_FILES where file_mtime > TRD_MTIME; if NEWER_FILES non-empty → STALE_DRIFT=true, NEWER_COUNT=len(NEWER_FILES); else STALE_DRIFT=false
+       - **Step 5 — Gate Decision**: STALE = (STALE_AGE OR STALE_DRIFT). If STALE=false → print "Staleness check: TRD is current" and RETURN. If STALE=true → build combined message: if STALE_AGE → append "TRD is ${AGE_HOURS}h old (threshold: 24h)."; if STALE_DRIFT → append "${NEWER_COUNT} source file(s) are newer than the TRD:" + list up to 10 file paths (append "(and ${NEWER_COUNT-10} more)" if >10); append "Running /ensemble:refine-trd before implementation." and invoke `/ensemble:refine-trd <TRD_PATH>`
        - **Step 6 — Post-Refinement Decision**: if refine-trd exits 0 → print "Staleness gate satisfied — TRD refreshed. Proceeding with implementation." and RETURN (no re-check); if refine-trd exits non-zero → print "STALENESS GATE FAILURE: TRD refinement failed. Fix the TRD manually and re-run." and HALT
        - **Known Limitation section**: document mtime reset on git clone/checkout/pull
   - Implementation AC:
@@ -126,6 +127,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given refine-trd exits non-zero, when post-refinement decision runs, then HALT is reached with the correct error message
 
 - [ ] **TRD-001-TEST**: Verify SKILL.md documents all required behaviors with complete accuracy (1h) [verifies TRD-001] [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008] [depends: TRD-001]
+  - Validates PRD ACs: AC-001-1, AC-001-2, AC-002-1, AC-002-2, AC-003-1, AC-003-2, AC-004-1, AC-005-1, AC-008-1, AC-008-2
   - Target Files: `packages/development/skills/staleness-gate/SKILL.md`
   - Actions:
     1. Read the SKILL.md and verify: (a) all 6 algorithm steps are present, (b) both platform-specific stat variants documented, (c) exclusion list matches PRD REQ-002 exactly, (d) NEWER_FILES truncation at 10 entries specified, (e) post-refinement no-recheck is explicit, (f) Known Limitation section present
@@ -136,11 +138,8 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the exclusion list in SKILL.md, when compared to PRD REQ-002's list, then all excluded path patterns are present and correct
   - Proof of requirement: All 14 ACs from PRD-2026-022 map to documented SKILL.md behaviors
 
-### PR 2: Command Integration
-
-**Shippable State:** All three `implement-trd` flavors enforce the staleness gate on first invocation — no implementation starts against a TRD older than 24 hours or with newer source files; resume paths are unaffected.
-
 - [ ] **TRD-002**: Add TRD Staleness Gate step to `implement-trd-beads.yaml` Preflight (2h) [satisfies REQ-007] [depends: TRD-001]
+  - Validates PRD ACs: AC-006-1
   - Target File: `packages/development/commands/implement-trd-beads.yaml`
   - Actions:
     1. Insert new Preflight step between current step 6 (Resume Detection) and current step 7 (Feature Branch Creation). The new step becomes order 7; renumber existing steps 7→8, 8→9, 9→10, 10→11, 11→12.
@@ -163,6 +162,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given a resume (ROOT_EPIC_ID set in step 6), when Preflight step 7 runs, then it prints the skip message and continues to step 8 without any file system checks
 
 - [ ] **TRD-002-TEST**: Verify implement-trd-beads staleness step is correct, correctly numbered, and does not disturb existing step references (1h) [verifies TRD-002] [satisfies REQ-007] [depends: TRD-002]
+  - Validates PRD ACs: AC-006-1
   - Target File: `packages/development/commands/implement-trd-beads.yaml`
   - Actions:
     1. Parse Preflight steps; confirm new step order 7 exists with title "TRD Staleness Gate"
@@ -176,6 +176,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the Preflight step list, when step orders 1-12 are enumerated, then all are sequential with no gaps
 
 - [ ] **TRD-003**: Add TRD Staleness Gate step to `implement-trd.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+  - Validates PRD ACs: AC-006-2
   - Target File: `packages/development/commands/implement-trd.yaml`
   - Actions:
     1. Insert new Preflight step between current step 1 (Git Town Verification) and current step 2 (Feature Branch Creation). New step becomes order 2; renumber existing steps 2→3, 3→4, 4→5, 5→6.
@@ -200,6 +201,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the feature branch `feature/<TRD_SLUG>-sprint-1` already exists, when Preflight step 2 runs, then IS_RESUME=true and the gate is skipped
 
 - [ ] **TRD-003-TEST**: Verify implement-trd staleness step is correct and correctly numbered (0.5h) [verifies TRD-003] [satisfies REQ-007] [depends: TRD-003]
+  - Validates PRD ACs: AC-006-2
   - Target File: `packages/development/commands/implement-trd.yaml`
   - Actions:
     1. Confirm new step order 2 with title "TRD Staleness Gate" exists
@@ -212,6 +214,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the Preflight steps, when steps 1-6 are enumerated, then all are sequential with no gaps
 
 - [ ] **TRD-004**: Add TRD Staleness Gate step to `beads-build.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+  - Validates PRD ACs: AC-006-1, AC-007-1, AC-007-2
   - Target File: `packages/development/commands/beads-build.yaml`
   - Actions:
     1. Insert new Preflight step between current step 5 (TRD Augmentation Setup) and current step 6 (Strategy Detection). New step becomes order 6; renumber existing steps 6→7, 7→8.
@@ -236,6 +239,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given `beads-build --trd <stale-trd>` with no existing root epic, when Preflight step 6 runs, then the staleness gate executes before any execution begins
 
 - [ ] **TRD-004-TEST**: Verify beads-build staleness step is correct and correctly numbered (0.5h) [verifies TRD-004] [satisfies REQ-007] [depends: TRD-004]
+  - Validates PRD ACs: AC-006-1, AC-007-1, AC-007-2
   - Target File: `packages/development/commands/beads-build.yaml`
   - Actions:
     1. Confirm new step order 6 with title "TRD Staleness Gate" exists
@@ -262,14 +266,11 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
 
 ## Sprint Planning
 
-### Sprint 1 (PR 1 + PR 2 — single sprint, ~9.5h total)
+### Sprint 1 (single PR — ~10.5h total)
 
-PR 1 can be reviewed independently (skill file only). PR 2 depends on PR 1 merging. Both fit within a single sprint given the bounded scope.
+All 9 tasks ship in one PR. TRD-001 (skill file) and TRD-001-TEST must complete first; TRD-002, TRD-003, TRD-004 can then execute in parallel (no file conflicts); TRD-005 runs last.
 
-- **PR 1 tasks** (3h): TRD-001, TRD-001-TEST
-- **PR 2 tasks** (6.5h): TRD-002, TRD-002-TEST, TRD-003, TRD-003-TEST, TRD-004, TRD-004-TEST, TRD-005
-
-TRD-002, TRD-003, TRD-004 can execute in parallel after TRD-001 merges (no file conflicts between the three command YAMLs).
+- **PR 1 tasks** (10.5h): TRD-001, TRD-001-TEST, TRD-002, TRD-002-TEST, TRD-003, TRD-003-TEST, TRD-004, TRD-004-TEST, TRD-005
 
 ---
 
@@ -335,8 +336,21 @@ Git mtime reset on clone/checkout is accepted and documented. Semantic staleness
 
 | Dimension | Score | Notes |
 |-----------|-------|-------|
-| Architecture completeness | 4.5 | All components, interfaces, data flows defined; platform-specific stat noted; mtime fallback documented |
-| Task coverage | 4.5 | All 8 REQs covered; all 5 impl tasks have paired test tasks; INFRA task for regen included |
-| Dependency clarity | 5.0 | Clean 2-level tree: TRD-001 → {TRD-002, TRD-003, TRD-004} → TRD-005; no cycles |
-| Estimate confidence | 4.5 | Well-scoped YAML edits; TRD-002 (beads renumbering 7→12) is most complex at 2h |
-| **Overall** | **4.63** | **PASS — ready for implementation** |
+| Architecture completeness | 4.75 | All components, interfaces, data flows defined; dual-condition algorithm now fully specified; both conditions always evaluated and reported |
+| Task coverage | 5.0 | All 8 REQs covered; Validates PRD ACs fields added to all impl/test tasks; full AC traceability |
+| Dependency clarity | 5.0 | Single PR; clean 2-level tree: TRD-001 → {TRD-002, TRD-003, TRD-004} → TRD-005; no cycles |
+| Estimate confidence | 5.0 | TRD-001 bumped to 3h (realistic for detailed SKILL.md); all other estimates unchanged |
+| **Overall** | **4.88** | **PASS — ready for implementation** |
+
+---
+
+## Changelog
+
+### v1.0.1 — 2026-06-01 (refined via /ensemble:refine-trd)
+
+- **Collapsed PR 1 + PR 2 into single PR**: skill file and command integration now ship together; Shippable State updated to describe user-observable enforcement across all three flavors
+- **Added `Validates PRD ACs:` fields** to TRD-001, TRD-001-TEST, TRD-002, TRD-002-TEST, TRD-003, TRD-003-TEST, TRD-004, TRD-004-TEST — full PRD AC sub-ID traceability now in place
+- **Dual-condition observability**: SKILL.md Step 4 now always runs (drift check no longer short-circuits on age); Step 5 builds a combined message when both age and drift conditions are true
+- **TRD-001 estimate**: 2h → 3h (more realistic for the level of specification detail required)
+- **Total estimated hours**: 9.5h → 10.5h
+- **Design Readiness Score**: 4.63 → 4.88 (improved)

--- a/docs/TRD/TRD-2026-023-trd-staleness-gate.md
+++ b/docs/TRD/TRD-2026-023-trd-staleness-gate.md
@@ -288,6 +288,33 @@ TRD-002, TRD-003, TRD-004 can execute in parallel after TRD-001 merges (no file 
 
 ---
 
+## Team Configuration
+
+> Auto-configured by `/ensemble:configure-team` on 2026-06-01
+>
+> **Complexity metrics:** tasks=9 | estimated_hours=9.5 | domains=2 (documentation, testing) | cross_cutting=1 | dependency_depth=3 | tier=**Medium**
+>
+> Medium tier: lead + builder roles only (no reviewer or QA — add manually if desired).
+
+```yaml
+team:
+  roles:
+    - name: lead
+      agent: tech-lead-orchestrator
+      owns:
+        - task-selection
+        - architecture-review
+        - final-approval
+    - name: builder
+      agents:
+        - documentation-specialist
+        - backend-developer
+      owns:
+        - implementation
+```
+
+---
+
 ## Quality Requirements
 
 ### Testing Standards

--- a/docs/TRD/TRD-2026-023-trd-staleness-gate.md
+++ b/docs/TRD/TRD-2026-023-trd-staleness-gate.md
@@ -1,0 +1,315 @@
+---
+document_id: TRD-2026-023
+prd_reference: docs/PRD/PRD-2026-022-trd-staleness-gate.md
+version: 1.0.0
+status: Draft
+date: 2026-06-01
+design_readiness_score: 4.63
+---
+
+# TRD-2026-023: TRD Staleness Gate
+
+Based on PRD: docs/PRD/PRD-2026-022-trd-staleness-gate.md
+
+---
+
+## Architecture Decision
+
+**Chosen approach: Option B — Shared Skill + Thin Reference Steps**
+
+A new skill file `packages/development/skills/staleness-gate/SKILL.md` defines the canonical staleness detection algorithm (mtime age check, source file drift check, `refine-trd` invocation, success/failure paths, resume skip logic). Each of the three `implement-trd` flavors adds a single thin Preflight step that supplies its flavor-specific IS_RESUME signal and delegates to the skill for all logic.
+
+**Why Option B over alternatives:**
+- Option A (full inline per command) would duplicate ~40 lines of action items across 3 files, creating drift risk as the exclusion list evolves.
+- Option C (inline on beads, abbreviated references) creates an asymmetry where two commands depend on a third for their full algorithm.
+- Option B keeps each command self-describing (the Preflight step says exactly what it does and where to find the algorithm) while making the algorithm a single-edit update path.
+
+**Alternatives considered:**
+- Option A: full inline duplication per command — rejected (maintenance burden)
+- Option C: full inline on beads, cross-references on others — rejected (asymmetric documentation)
+
+---
+
+## System Architecture
+
+### Components
+
+```
+packages/development/skills/staleness-gate/
+└── SKILL.md                          ← canonical staleness gate algorithm
+
+packages/development/commands/
+├── implement-trd-beads.yaml          ← Preflight step 7 added (new); steps 7-11 → 8-12
+├── implement-trd.yaml                ← Preflight step 2 added (new); steps 2-5 → 3-6
+└── beads-build.yaml                  ← Preflight step 6 added (new); steps 6-7 → 7-8
+```
+
+### Data Flow
+
+```
+$ARGUMENTS (TRD_PATH)
+      │
+      ▼
+Each command's new Preflight step
+      │
+      ├─── IS_RESUME? ─────yes──→ SKIP (print "skipped: resume")
+      │
+      no
+      │
+      ▼
+SKILL.md: staleness-gate
+      │
+      ├── stat TRD_PATH → TRD_MTIME
+      ├── Check age: (NOW - TRD_MTIME) > 86400s → STALE_AGE
+      ├── git ls-files | filter exclusions | mtime > TRD_MTIME → NEWER_FILES
+      │
+      ├─── Not stale ──→ RETURN (continue to next preflight step)
+      │
+      └─── Stale ──→ print message + invoke /ensemble:refine-trd <TRD_PATH>
+                          │
+                          ├── exit 0 ──→ RETURN (proceed without re-check)
+                          └── exit ≠0 ──→ HALT ("Fix TRD manually and re-run")
+```
+
+### Resume Detection Signals per Flavor
+
+| Flavor | IS_RESUME = true when |
+|--------|----------------------|
+| `implement-trd-beads` | ROOT_EPIC_ID found in `br list --json` for this TRD slug (Preflight step 6) |
+| `implement-trd` | `git branch --list feature/<TRD_SLUG>-sprint-1` returns a match (checked before branch creation) |
+| `beads-build --trd` | ROOT_EPIC_ID found in Epic Discovery step (Preflight step 4) |
+
+### Source File Exclusion List (REQ-002)
+
+Files excluded from the drift check — these do not signal staleness:
+- All paths matching `.gitignore` (via `git ls-files --exclude-standard`): covers `dist/`, `build/`, `node_modules/`, `coverage/`, `.beads.bd/`, `.bv/`, `.ntm/`, `.opencode/`, `.dolt/`
+- `packages/*/commands/ensemble/` — generated markdown command files
+- `packages/pi/prompts/` — generated pi prompt files
+- `packages/codex/.codex/` — generated codex skill files
+
+### Integration Points
+
+- **`/ensemble:refine-trd`**: invoked as a sub-command when staleness detected; exit code 0 = success, non-zero = failure
+- **`git ls-files --exclude-standard`**: lists tracked source files respecting `.gitignore`
+- **`stat`**: platform-aware mtime retrieval (macOS: `stat -f %m`; Linux: `stat -c %Y`; fallback: `python3 -c "import os; print(int(os.path.getmtime(...)))"`)
+
+### Known Limitation
+
+File mtimes reset to current time after `git clone`, `git checkout`, or `git pull`. A freshly-checked-out repo cannot detect semantic staleness introduced by checking out an old branch. This is documented in the PRD non-goals and in the SKILL.md.
+
+---
+
+## Master Task List
+
+### PR 1: Staleness Gate Skill
+
+**Shippable State:** The canonical staleness gate algorithm is documented in a standalone skill file that can be referenced by any command and manually applied; the algorithm itself is reviewable and testable in isolation.
+
+- [ ] **TRD-001**: Create `packages/development/skills/staleness-gate/SKILL.md` with the full staleness gate algorithm (2h) [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008]
+  - Target File: `packages/development/skills/staleness-gate/SKILL.md`
+  - Actions:
+    1. Create directory `packages/development/skills/staleness-gate/`
+    2. Write `SKILL.md` with the following canonical content:
+       - **Inputs table**: TRD_PATH, IS_RESUME (boolean), FLAVOR (string for messages)
+       - **Resume Detection by Flavor table** (all three flavors)
+       - **Step 1 — Resume Check**: if IS_RESUME=true → print "Staleness check: skipped (resume detected)" and RETURN
+       - **Step 2 — Get TRD mtime**: `TRD_MTIME=$(stat -f %m "<TRD_PATH>")` (macOS) OR `TRD_MTIME=$(stat -c %Y "<TRD_PATH>")` (Linux) OR `python3 -c "import os; print(int(os.path.getmtime('<TRD_PATH>')))"` (fallback); on failure → print "WARNING: Cannot determine TRD file age — skipping staleness check." and RETURN
+       - **Step 3 — Age Check**: `CURRENT_TIME=$(date +%s); AGE_SECONDS=$((CURRENT_TIME - TRD_MTIME)); AGE_HOURS=$((AGE_SECONDS / 3600)); if AGE_HOURS > 24 → STALE=true, STALE_REASON=age`
+       - **Step 4 — Source File Drift Check**: `git ls-files --exclude-standard | grep -vE "^packages/[^/]+/commands/ensemble/|^packages/pi/prompts/|^packages/codex/\.codex/"` → for each file get mtime → collect NEWER_FILES where file_mtime > TRD_MTIME; if NEWER_FILES non-empty and not already stale → STALE=true, STALE_REASON=drift
+       - **Step 5 — Gate Decision**: if STALE=false → print "Staleness check: TRD is current" and RETURN; if STALE=true and STALE_REASON=age → print "STALENESS GATE: TRD is ${AGE_HOURS}h old (threshold: 24h). Running /ensemble:refine-trd before implementation." and invoke `/ensemble:refine-trd <TRD_PATH>`; if STALE=true and STALE_REASON=drift → print "STALENESS GATE: ${NEWER_COUNT} source files are newer than the TRD." + list up to 10 file paths (show count if >10) + "Running /ensemble:refine-trd before implementation." and invoke `/ensemble:refine-trd <TRD_PATH>`
+       - **Step 6 — Post-Refinement Decision**: if refine-trd exits 0 → print "Staleness gate satisfied — TRD refreshed. Proceeding with implementation." and RETURN (no re-check); if refine-trd exits non-zero → print "STALENESS GATE FAILURE: TRD refinement failed. Fix the TRD manually and re-run." and HALT
+       - **Known Limitation section**: document mtime reset on git clone/checkout/pull
+  - Implementation AC:
+    - Given IS_RESUME=true, when the skill runs, then it returns immediately without performing any mtime checks
+    - Given TRD is 36h old with no newer source files, when the skill runs, then it prints the age message and invokes refine-trd
+    - Given refine-trd exits 0, when post-refinement decision runs, then implementation proceeds without a second staleness check
+    - Given refine-trd exits non-zero, when post-refinement decision runs, then HALT is reached with the correct error message
+
+- [ ] **TRD-001-TEST**: Verify SKILL.md documents all required behaviors with complete accuracy (1h) [verifies TRD-001] [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008] [depends: TRD-001]
+  - Target Files: `packages/development/skills/staleness-gate/SKILL.md`
+  - Actions:
+    1. Read the SKILL.md and verify: (a) all 6 algorithm steps are present, (b) both platform-specific stat variants documented, (c) exclusion list matches PRD REQ-002 exactly, (d) NEWER_FILES truncation at 10 entries specified, (e) post-refinement no-recheck is explicit, (f) Known Limitation section present
+    2. Verify Given/When/Then format on all Implementation AC items
+    3. Verify resume detection table covers all 3 flavors
+  - Test AC:
+    - Given the SKILL.md, when each REQ (001-006, 008) is checked against the document, then every AC from the PRD has a corresponding documented behavior
+    - Given the exclusion list in SKILL.md, when compared to PRD REQ-002's list, then all excluded path patterns are present and correct
+  - Proof of requirement: All 14 ACs from PRD-2026-022 map to documented SKILL.md behaviors
+
+### PR 2: Command Integration
+
+**Shippable State:** All three `implement-trd` flavors enforce the staleness gate on first invocation — no implementation starts against a TRD older than 24 hours or with newer source files; resume paths are unaffected.
+
+- [ ] **TRD-002**: Add TRD Staleness Gate step to `implement-trd-beads.yaml` Preflight (2h) [satisfies REQ-007] [depends: TRD-001]
+  - Target File: `packages/development/commands/implement-trd-beads.yaml`
+  - Actions:
+    1. Insert new Preflight step between current step 6 (Resume Detection) and current step 7 (Feature Branch Creation). The new step becomes order 7; renumber existing steps 7→8, 8→9, 9→10, 10→11, 11→12.
+    2. New step content:
+       ```yaml
+       - order: 7
+         title: TRD Staleness Gate
+         description: |
+           Check TRD freshness before committing to a feature branch. Skip on resume.
+           Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+         actions:
+           - "If resume was detected in Preflight step 6 (ROOT_EPIC_ID is set / IS_RESUME=true): skip this step — staleness check does not apply to resuming an existing scaffold. Print 'Staleness check: skipped (resume detected)' and continue to step 8."
+           - "If first invocation (IS_RESUME=false / no ROOT_EPIC_ID found in step 6): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 4 and IS_RESUME=false."
+           - "On HALT from skill: do not proceed. Implementation stops."
+           - "On RETURN from skill (TRD fresh or successfully refined): continue to Preflight step 8 (Feature Branch Creation)."
+       ```
+    3. Update existing step numbers: change `order: 7` → `order: 8` through `order: 11` → `order: 12` for the five subsequent Preflight steps.
+  - Implementation AC:
+    - Given a stale TRD and first invocation, when Preflight step 7 runs, then the SKILL.md gate executes before any feature branch is created
+    - Given a resume (ROOT_EPIC_ID set in step 6), when Preflight step 7 runs, then it prints the skip message and continues to step 8 without any file system checks
+
+- [ ] **TRD-002-TEST**: Verify implement-trd-beads staleness step is correct, correctly numbered, and does not disturb existing step references (1h) [verifies TRD-002] [satisfies REQ-007] [depends: TRD-002]
+  - Target File: `packages/development/commands/implement-trd-beads.yaml`
+  - Actions:
+    1. Parse Preflight steps; confirm new step order 7 exists with title "TRD Staleness Gate"
+    2. Confirm Feature Branch Creation is now order 8 (was 7)
+    3. Confirm Traceability Validation Gate is now order 12 (was 11)
+    4. Confirm step 7 references `packages/development/skills/staleness-gate/SKILL.md`
+    5. Confirm step 7 IS_RESUME condition references Preflight step 6 (Resume Detection)
+    6. Run `npm run validate` — must exit 0
+  - Test AC:
+    - Given the updated YAML, when `npm run validate` runs, then it exits 0 with no schema errors
+    - Given the Preflight step list, when step orders 1-12 are enumerated, then all are sequential with no gaps
+
+- [ ] **TRD-003**: Add TRD Staleness Gate step to `implement-trd.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+  - Target File: `packages/development/commands/implement-trd.yaml`
+  - Actions:
+    1. Insert new Preflight step between current step 1 (Git Town Verification) and current step 2 (Feature Branch Creation). New step becomes order 2; renumber existing steps 2→3, 3→4, 4→5, 5→6.
+    2. New step content:
+       ```yaml
+       - order: 2
+         title: TRD Staleness Gate
+         description: |
+           Check TRD freshness before creating a feature branch. Skip if branch already exists (resume).
+           Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+         actions:
+           - "Derive TRD_PATH from $ARGUMENTS (the .md path argument)."
+           - "Derive TRD_SLUG from TRD_PATH filename (lowercase, replace non-alphanumeric with hyphens)."
+           - "Resume detection: run 'git branch --list feature/<TRD_SLUG>-sprint-1'. If this returns a branch name: IS_RESUME=true. If empty: IS_RESUME=false."
+           - "Execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH and IS_RESUME."
+           - "On HALT from skill: do not proceed. Implementation stops."
+           - "On RETURN from skill: continue to step 3 (Feature Branch Creation)."
+       ```
+    3. Update existing step numbers: `order: 2` → `order: 3` through `order: 5` → `order: 6`.
+  - Implementation AC:
+    - Given a stale TRD and no existing feature branch, when Preflight step 2 runs, then the gate executes before `git town hack` creates any branch
+    - Given the feature branch `feature/<TRD_SLUG>-sprint-1` already exists, when Preflight step 2 runs, then IS_RESUME=true and the gate is skipped
+
+- [ ] **TRD-003-TEST**: Verify implement-trd staleness step is correct and correctly numbered (0.5h) [verifies TRD-003] [satisfies REQ-007] [depends: TRD-003]
+  - Target File: `packages/development/commands/implement-trd.yaml`
+  - Actions:
+    1. Confirm new step order 2 with title "TRD Staleness Gate" exists
+    2. Confirm Feature Branch Creation is now order 3 (was 2)
+    3. Confirm Resource Assessment is now order 6 (was 5)
+    4. Confirm step 2 derives TRD_SLUG and checks `git branch --list` for resume detection
+    5. Run `npm run validate` — must exit 0
+  - Test AC:
+    - Given the updated YAML, when `npm run validate` runs, then it exits 0
+    - Given the Preflight steps, when steps 1-6 are enumerated, then all are sequential with no gaps
+
+- [ ] **TRD-004**: Add TRD Staleness Gate step to `beads-build.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+  - Target File: `packages/development/commands/beads-build.yaml`
+  - Actions:
+    1. Insert new Preflight step between current step 5 (TRD Augmentation Setup) and current step 6 (Strategy Detection). New step becomes order 6; renumber existing steps 6→7, 7→8.
+    2. New step content:
+       ```yaml
+       - order: 6
+         title: TRD Staleness Gate
+         description: |
+           When TRD_MODE=true and first invocation, check TRD freshness before execution begins.
+           Skip when TRD_MODE=false or when resuming an existing epic.
+           Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+         actions:
+           - "If TRD_MODE=false: skip this step entirely. Print 'Staleness check: skipped (no --trd flag)' and continue to step 7."
+           - "If TRD_MODE=true AND ROOT_EPIC_ID was found in Preflight step 4 (Epic Discovery) — IS_RESUME=true: skip this step. Print 'Staleness check: skipped (resume detected)' and continue to step 7."
+           - "If TRD_MODE=true AND no ROOT_EPIC_ID found in step 4 (first invocation): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 1 and IS_RESUME=false."
+           - "On HALT from skill: do not proceed. Implementation stops."
+           - "On RETURN from skill: continue to step 7 (Strategy Detection)."
+       ```
+    3. Update existing step numbers: `order: 6` → `order: 7` and `order: 7` → `order: 8`.
+  - Implementation AC:
+    - Given `beads-build` invoked without `--trd`, when Preflight step 6 runs, then it prints the no-trd skip message and continues
+    - Given `beads-build --trd <stale-trd>` with no existing root epic, when Preflight step 6 runs, then the staleness gate executes before any execution begins
+
+- [ ] **TRD-004-TEST**: Verify beads-build staleness step is correct and correctly numbered (0.5h) [verifies TRD-004] [satisfies REQ-007] [depends: TRD-004]
+  - Target File: `packages/development/commands/beads-build.yaml`
+  - Actions:
+    1. Confirm new step order 6 with title "TRD Staleness Gate" exists
+    2. Confirm Strategy Detection is now order 7 (was 6)
+    3. Confirm Team Configuration Detection is now order 8 (was 7)
+    4. Confirm step 6 handles TRD_MODE=false and resume cases explicitly
+    5. Run `npm run validate` — must exit 0
+  - Test AC:
+    - Given the updated YAML, when `npm run validate` runs, then it exits 0
+    - Given the Preflight steps, when steps 1-8 are enumerated, then all are sequential with no gaps
+
+- [ ] **TRD-005**: Regenerate all downstream artifacts (0.5h) [satisfies INFRA] [depends: TRD-002] [depends: TRD-003] [depends: TRD-004]
+  - Target Files: all generated `.md`, pi, codex artifacts
+  - Actions:
+    1. Run `npm run generate` — must exit 0
+    2. Run `npm run validate` — must exit 0
+    3. Run `npm run generate:pi`
+    4. Run `npm run generate:codex`
+    5. Stage and commit all changed artifacts
+  - Implementation AC:
+    - Given all three command YAMLs updated, when `npm run generate && npm run validate` runs, then both exit 0 and no new schema errors are introduced
+
+---
+
+## Sprint Planning
+
+### Sprint 1 (PR 1 + PR 2 — single sprint, ~9.5h total)
+
+PR 1 can be reviewed independently (skill file only). PR 2 depends on PR 1 merging. Both fit within a single sprint given the bounded scope.
+
+- **PR 1 tasks** (3h): TRD-001, TRD-001-TEST
+- **PR 2 tasks** (6.5h): TRD-002, TRD-002-TEST, TRD-003, TRD-003-TEST, TRD-004, TRD-004-TEST, TRD-005
+
+TRD-002, TRD-003, TRD-004 can execute in parallel after TRD-001 merges (no file conflicts between the three command YAMLs).
+
+---
+
+## Acceptance Criteria Traceability
+
+| REQ | Description | Implementation Tasks | Test Tasks |
+|-----|-------------|---------------------|------------|
+| REQ-001 | Age-based staleness detection (>24h) | TRD-001 | TRD-001-TEST |
+| REQ-002 | Content-drift staleness (newer source files) | TRD-001 | TRD-001-TEST |
+| REQ-003 | Auto-invoke refine-trd on stale detection | TRD-001 | TRD-001-TEST |
+| REQ-004 | Proceed after successful refinement | TRD-001 | TRD-001-TEST |
+| REQ-005 | Hard stop on refinement failure | TRD-001 | TRD-001-TEST |
+| REQ-006 | Skip staleness check on resume | TRD-001 | TRD-001-TEST |
+| REQ-007 | Apply gate to all three flavors | TRD-002, TRD-003, TRD-004 | TRD-002-TEST, TRD-003-TEST, TRD-004-TEST |
+| REQ-008 | Message identifies condition + files | TRD-001 | TRD-001-TEST |
+
+---
+
+## Quality Requirements
+
+### Testing Standards
+- `npm run validate` must exit 0 after each YAML edit (step numbering is schema-validated)
+- Test tasks verify both the skill content (TRD-001-TEST) and the command integration (TRD-002/3/4-TEST)
+
+### Compatibility
+- No changes to existing Preflight step logic — only insertions + renumbering
+- All resume paths explicitly preserved per flavor
+- Cross-session resume unaffected (staleness step is skipped on resume for all three flavors)
+
+### Known Limitation (from PRD)
+Git mtime reset on clone/checkout is accepted and documented. Semantic staleness detection is out of scope for this release.
+
+---
+
+## Design Readiness Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Architecture completeness | 4.5 | All components, interfaces, data flows defined; platform-specific stat noted; mtime fallback documented |
+| Task coverage | 4.5 | All 8 REQs covered; all 5 impl tasks have paired test tasks; INFRA task for regen included |
+| Dependency clarity | 5.0 | Clean 2-level tree: TRD-001 → {TRD-002, TRD-003, TRD-004} → TRD-005; no cycles |
+| Estimate confidence | 4.5 | Well-scoped YAML edits; TRD-002 (beads renumbering 7→12) is most complex at 2h |
+| **Overall** | **4.63** | **PASS — ready for implementation** |

--- a/docs/TRD/TRD-2026-023-trd-staleness-gate.md
+++ b/docs/TRD/TRD-2026-023-trd-staleness-gate.md
@@ -105,7 +105,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
 
 **Shippable State:** All three `implement-trd` flavors enforce the staleness gate on first invocation — no implementation starts against a TRD older than 24 hours or with newer source files; resume paths are unaffected.
 
-- [ ] **TRD-001**: Create `packages/development/skills/staleness-gate/SKILL.md` with the full staleness gate algorithm (3h) [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008]
+- [x] **TRD-001**: Create `packages/development/skills/staleness-gate/SKILL.md` with the full staleness gate algorithm (3h) [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008]
   - Validates PRD ACs: AC-001-1, AC-001-2, AC-002-1, AC-002-2, AC-003-1, AC-003-2, AC-004-1, AC-005-1, AC-008-1, AC-008-2
   - Target File: `packages/development/skills/staleness-gate/SKILL.md`
   - Actions:
@@ -126,7 +126,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given refine-trd exits 0, when post-refinement decision runs, then implementation proceeds without a second staleness check
     - Given refine-trd exits non-zero, when post-refinement decision runs, then HALT is reached with the correct error message
 
-- [ ] **TRD-001-TEST**: Verify SKILL.md documents all required behaviors with complete accuracy (1h) [verifies TRD-001] [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008] [depends: TRD-001]
+- [x] **TRD-001-TEST**: Verify SKILL.md documents all required behaviors with complete accuracy (1h) [verifies TRD-001] [satisfies REQ-001] [satisfies REQ-002] [satisfies REQ-003] [satisfies REQ-004] [satisfies REQ-005] [satisfies REQ-006] [satisfies REQ-008] [depends: TRD-001]
   - Validates PRD ACs: AC-001-1, AC-001-2, AC-002-1, AC-002-2, AC-003-1, AC-003-2, AC-004-1, AC-005-1, AC-008-1, AC-008-2
   - Target Files: `packages/development/skills/staleness-gate/SKILL.md`
   - Actions:
@@ -138,7 +138,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the exclusion list in SKILL.md, when compared to PRD REQ-002's list, then all excluded path patterns are present and correct
   - Proof of requirement: All 14 ACs from PRD-2026-022 map to documented SKILL.md behaviors
 
-- [ ] **TRD-002**: Add TRD Staleness Gate step to `implement-trd-beads.yaml` Preflight (2h) [satisfies REQ-007] [depends: TRD-001]
+- [x] **TRD-002**: Add TRD Staleness Gate step to `implement-trd-beads.yaml` Preflight (2h) [satisfies REQ-007] [depends: TRD-001]
   - Validates PRD ACs: AC-006-1
   - Target File: `packages/development/commands/implement-trd-beads.yaml`
   - Actions:
@@ -161,7 +161,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given a stale TRD and first invocation, when Preflight step 7 runs, then the SKILL.md gate executes before any feature branch is created
     - Given a resume (ROOT_EPIC_ID set in step 6), when Preflight step 7 runs, then it prints the skip message and continues to step 8 without any file system checks
 
-- [ ] **TRD-002-TEST**: Verify implement-trd-beads staleness step is correct, correctly numbered, and does not disturb existing step references (1h) [verifies TRD-002] [satisfies REQ-007] [depends: TRD-002]
+- [x] **TRD-002-TEST**: Verify implement-trd-beads staleness step is correct, correctly numbered, and does not disturb existing step references (1h) [verifies TRD-002] [satisfies REQ-007] [depends: TRD-002]
   - Validates PRD ACs: AC-006-1
   - Target File: `packages/development/commands/implement-trd-beads.yaml`
   - Actions:
@@ -175,7 +175,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the updated YAML, when `npm run validate` runs, then it exits 0 with no schema errors
     - Given the Preflight step list, when step orders 1-12 are enumerated, then all are sequential with no gaps
 
-- [ ] **TRD-003**: Add TRD Staleness Gate step to `implement-trd.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+- [x] **TRD-003**: Add TRD Staleness Gate step to `implement-trd.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
   - Validates PRD ACs: AC-006-2
   - Target File: `packages/development/commands/implement-trd.yaml`
   - Actions:
@@ -200,7 +200,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given a stale TRD and no existing feature branch, when Preflight step 2 runs, then the gate executes before `git town hack` creates any branch
     - Given the feature branch `feature/<TRD_SLUG>-sprint-1` already exists, when Preflight step 2 runs, then IS_RESUME=true and the gate is skipped
 
-- [ ] **TRD-003-TEST**: Verify implement-trd staleness step is correct and correctly numbered (0.5h) [verifies TRD-003] [satisfies REQ-007] [depends: TRD-003]
+- [x] **TRD-003-TEST**: Verify implement-trd staleness step is correct and correctly numbered (0.5h) [verifies TRD-003] [satisfies REQ-007] [depends: TRD-003]
   - Validates PRD ACs: AC-006-2
   - Target File: `packages/development/commands/implement-trd.yaml`
   - Actions:
@@ -213,7 +213,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the updated YAML, when `npm run validate` runs, then it exits 0
     - Given the Preflight steps, when steps 1-6 are enumerated, then all are sequential with no gaps
 
-- [ ] **TRD-004**: Add TRD Staleness Gate step to `beads-build.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
+- [x] **TRD-004**: Add TRD Staleness Gate step to `beads-build.yaml` Preflight (1h) [satisfies REQ-007] [depends: TRD-001]
   - Validates PRD ACs: AC-006-1, AC-007-1, AC-007-2
   - Target File: `packages/development/commands/beads-build.yaml`
   - Actions:
@@ -238,7 +238,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given `beads-build` invoked without `--trd`, when Preflight step 6 runs, then it prints the no-trd skip message and continues
     - Given `beads-build --trd <stale-trd>` with no existing root epic, when Preflight step 6 runs, then the staleness gate executes before any execution begins
 
-- [ ] **TRD-004-TEST**: Verify beads-build staleness step is correct and correctly numbered (0.5h) [verifies TRD-004] [satisfies REQ-007] [depends: TRD-004]
+- [x] **TRD-004-TEST**: Verify beads-build staleness step is correct and correctly numbered (0.5h) [verifies TRD-004] [satisfies REQ-007] [depends: TRD-004]
   - Validates PRD ACs: AC-006-1, AC-007-1, AC-007-2
   - Target File: `packages/development/commands/beads-build.yaml`
   - Actions:
@@ -251,7 +251,7 @@ File mtimes reset to current time after `git clone`, `git checkout`, or `git pul
     - Given the updated YAML, when `npm run validate` runs, then it exits 0
     - Given the Preflight steps, when steps 1-8 are enumerated, then all are sequential with no gaps
 
-- [ ] **TRD-005**: Regenerate all downstream artifacts (0.5h) [satisfies INFRA] [depends: TRD-002] [depends: TRD-003] [depends: TRD-004]
+- [x] **TRD-005**: Regenerate all downstream artifacts (0.5h) [satisfies INFRA] [depends: TRD-002] [depends: TRD-003] [depends: TRD-004]
   - Target Files: all generated `.md`, pi, codex artifacts
   - Actions:
     1. Run `npm run generate` — must exit 0

--- a/packages/codex/.codex/skills/commands/ensemble-beads-build/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-beads-build/SKILL.md
@@ -83,14 +83,26 @@ Key behaviors:
    - Classify task type: if task.id ends in -TEST suffix, mark is_test_task=true; extract verifies_task_id and satisfies_req_id; store in TASK_TRACEABILITY[task.id]
    - Print "TRD augmentations: enabled (traceability, checkbox sync, requirement report)"
 
-**6. Strategy Detection**
+**6. TRD Staleness Gate**
+   When TRD_MODE=true and first invocation, check TRD freshness before execution begins.
+Skip when TRD_MODE=false or when resuming an existing epic.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - If TRD_MODE=false: skip this step entirely. Print "Staleness check: skipped (no --trd flag)" and continue to step 7.
+   - If TRD_MODE=true AND ROOT_EPIC_ID was found in Preflight step 4 (Epic Discovery) — IS_RESUME=true: skip this step. Print "Staleness check: skipped (resume detected)" and continue to step 7.
+   - If TRD_MODE=true AND no ROOT_EPIC_ID found in step 4 (first invocation): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 1 and IS_RESUME=false.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill: continue to step 7 (Strategy Detection).
+
+**7. Strategy Detection**
    Determine implementation strategy from arguments, TRD content, or auto-detection
 
    - Priority: --strategy arg -> TRD explicit (if TRD_MODE) -> auto-detect from bead titles/descriptions -> default (tdd)
    - Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
    - Store STRATEGY; print "Strategy: <STRATEGY>"
 
-**7. Team Configuration Detection**
+**8. Team Configuration Detection**
    Detect team configuration from --team-config argument or bead metadata, default to single-agent
 
    - If TRD_MODE=true: check TRD "## Team Configuration" section; if found parse YAML block; validate schema (roles array, lead and builder roles required); set TEAM_MODE=true, TEAM_ROLES; else fall through

--- a/packages/codex/.codex/skills/commands/ensemble-implement-trd-beads/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-implement-trd-beads/SKILL.md
@@ -147,7 +147,17 @@ Key behaviors:
    - 
    - When TEAM_MODE=false AND resume detected: existing v2.1.0 resume behavior unchanged
 
-**7. Feature Branch Creation**
+**7. TRD Staleness Gate**
+   Check TRD freshness before committing to a feature branch. Skip on resume.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - If resume was detected in Preflight step 6 (ROOT_EPIC_ID is set / IS_RESUME=true): skip this step — staleness check does not apply to resuming an existing scaffold. Print 'Staleness check: skipped (resume detected)' and continue to step 8.
+   - If first invocation (IS_RESUME=false / no ROOT_EPIC_ID found in step 6): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 4 and IS_RESUME=false.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill (TRD fresh or successfully refined): continue to Preflight step 8 (Feature Branch Creation).
+
+**8. Feature Branch Creation**
    Create or switch to feature branch for TRD implementation
 
    - branch_prefix = 'pr' if PR_FORMAT=true else 'phase'; branch_name = 'feature/<TRD_SLUG>-<branch_prefix>-1'; CURRENT_PHASE_BRANCH = branch_name; PHASE_BRANCH_MAP = {1: branch_name}; PHASE_PR_MAP = {}
@@ -155,13 +165,13 @@ Key behaviors:
    - If exists: git switch <branch_name>
    - If not exists: git town hack <branch_name> (fallback: git switch -c <branch_name>)
 
-**8. Strategy Detection**
+**9. Strategy Detection**
    Determine implementation strategy from arguments, TRD content, or auto-detection
 
    - Priority: $ARGUMENTS strategy=X -> TRD explicit -> constitution -> auto-detect -> default (tdd)
    - Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
 
-**9. Team Configuration Detection**
+**10. Team Configuration Detection**
    Determine team mode using precedence order: (1) TRD ## Team Configuration section,
 (2) command YAML team: section, (3) no team (single-agent). Sets TEAM_MODE,
 TEAM_CONFIG_SOURCE, TEAM_ROLES, REVIEWER_ENABLED, and QA_ENABLED for all subsequent
@@ -252,7 +262,7 @@ FR-5.1, FR-5.2, FR-5.3, FR-5.4, FR-5.5, FR-5.6, NFR-1.3, NFR-4.2
    -   - Identical to Case 3
    - Record which steps are skipped in the team configuration summary printed during this Preflight step.
 
-**10. Marketplace Preflight Check**
+**11. Marketplace Preflight Check**
    Before execution begins, check for marketplace capability gaps that may affect team
 config quality. Presents suggestions for missing agents/skills and installs approved
 plugins. Re-reads team config from TRD after installation if agents referenced in TRD
@@ -279,7 +289,7 @@ team config are now available. AC: FR-11.1 through FR-11.6, AC-8.1 through AC-8.
    -   If newly installed agents are NOT referenced in TRD team config: log 'Note: newly installed agents not referenced in TRD team config. Consider re-running /create-trd to update team configuration.'
    - Step 8 — If user declines all suggestions: proceed with existing team config and available agents
 
-**11. Traceability Validation Gate**
+**12. Traceability Validation Gate**
    Run validate-requirements as an automatic preflight gate before scaffolding begins.
 Checks that PRD requirements have TRD task coverage, that [satisfies] annotations
 reference real REQ-NNN IDs, and that every user-facing task has a paired -TEST task.

--- a/packages/codex/.codex/skills/commands/ensemble-implement-trd/SKILL.md
+++ b/packages/codex/.codex/skills/commands/ensemble-implement-trd/SKILL.md
@@ -31,7 +31,19 @@ development including planning, implementation, testing, and quality gates.
    - If validation fails, escalate with specific error message
    - Ensure clean working directory (git status)
 
-**2. Feature Branch Creation**
+**2. TRD Staleness Gate**
+   Check TRD freshness before creating a feature branch. Skip if branch already exists (resume).
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - Derive TRD_PATH from $ARGUMENTS (the .md path argument).
+   - Derive TRD_SLUG from TRD_PATH filename (lowercase, replace non-alphanumeric with hyphens).
+   - Resume detection: run 'git branch --list feature/<TRD_SLUG>-sprint-1'. If this returns a branch name: IS_RESUME=true. If empty: IS_RESUME=false.
+   - Execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH and IS_RESUME.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill: continue to step 3 (Feature Branch Creation).
+
+**3. Feature Branch Creation**
    Create sprint-1 feature branch using git-town skill interview template
 
    - Load interview template from packages/git/skills/git-town/templates/interview-branch-creation.md
@@ -42,13 +54,13 @@ development including planning, implementation, testing, and quality gates.
    - Execute - git-town hack feature/<trd-slug>-sprint-1 --parent <base-branch>
    - Verify branch creation successful (check git branch output)
 
-**3. TRD Ingestion**
+**4. TRD Ingestion**
    Parse and analyze existing TRD document with checkbox tracking
 
-**4. Technical Feasibility Review**
+**5. Technical Feasibility Review**
    Validate implementation approach and architecture
 
-**5. Resource Assessment**
+**6. Resource Assessment**
    Identify required specialist agents and tools
 
 ### Phase 2: Ensemble Orchestrator Delegation

--- a/packages/development/commands/beads-build.yaml
+++ b/packages/development/commands/beads-build.yaml
@@ -94,6 +94,19 @@ workflow:
             - 'Print "TRD augmentations: enabled (traceability, checkbox sync, requirement report)"'
 
         - order: 6
+          title: TRD Staleness Gate
+          description: |
+            When TRD_MODE=true and first invocation, check TRD freshness before execution begins.
+            Skip when TRD_MODE=false or when resuming an existing epic.
+            Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+          actions:
+            - 'If TRD_MODE=false: skip this step entirely. Print "Staleness check: skipped (no --trd flag)" and continue to step 7.'
+            - 'If TRD_MODE=true AND ROOT_EPIC_ID was found in Preflight step 4 (Epic Discovery) — IS_RESUME=true: skip this step. Print "Staleness check: skipped (resume detected)" and continue to step 7.'
+            - 'If TRD_MODE=true AND no ROOT_EPIC_ID found in step 4 (first invocation): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 1 and IS_RESUME=false.'
+            - 'On HALT from skill: do not proceed. Implementation stops.'
+            - 'On RETURN from skill: continue to step 7 (Strategy Detection).'
+
+        - order: 7
           title: Strategy Detection
           description: Determine implementation strategy from arguments, TRD content, or auto-detection
           actions:
@@ -101,7 +114,7 @@ workflow:
             - 'Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd'
             - 'Store STRATEGY; print "Strategy: <STRATEGY>"'
 
-        - order: 7
+        - order: 8
           title: Team Configuration Detection
           description: Detect team configuration from --team-config argument or bead metadata, default to single-agent
           actions:

--- a/packages/development/commands/ensemble/beads-build.md
+++ b/packages/development/commands/ensemble/beads-build.md
@@ -80,14 +80,26 @@ Key behaviors:
    - Classify task type: if task.id ends in -TEST suffix, mark is_test_task=true; extract verifies_task_id and satisfies_req_id; store in TASK_TRACEABILITY[task.id]
    - Print "TRD augmentations: enabled (traceability, checkbox sync, requirement report)"
 
-**6. Strategy Detection**
+**6. TRD Staleness Gate**
+   When TRD_MODE=true and first invocation, check TRD freshness before execution begins.
+Skip when TRD_MODE=false or when resuming an existing epic.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - If TRD_MODE=false: skip this step entirely. Print "Staleness check: skipped (no --trd flag)" and continue to step 7.
+   - If TRD_MODE=true AND ROOT_EPIC_ID was found in Preflight step 4 (Epic Discovery) — IS_RESUME=true: skip this step. Print "Staleness check: skipped (resume detected)" and continue to step 7.
+   - If TRD_MODE=true AND no ROOT_EPIC_ID found in step 4 (first invocation): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 1 and IS_RESUME=false.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill: continue to step 7 (Strategy Detection).
+
+**7. Strategy Detection**
    Determine implementation strategy from arguments, TRD content, or auto-detection
 
    - Priority: --strategy arg -> TRD explicit (if TRD_MODE) -> auto-detect from bead titles/descriptions -> default (tdd)
    - Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
    - Store STRATEGY; print "Strategy: <STRATEGY>"
 
-**7. Team Configuration Detection**
+**8. Team Configuration Detection**
    Detect team configuration from --team-config argument or bead metadata, default to single-agent
 
    - If TRD_MODE=true: check TRD "## Team Configuration" section; if found parse YAML block; validate schema (roles array, lead and builder roles required); set TEAM_MODE=true, TEAM_ROLES; else fall through

--- a/packages/development/commands/ensemble/implement-trd-beads.md
+++ b/packages/development/commands/ensemble/implement-trd-beads.md
@@ -144,7 +144,17 @@ Key behaviors:
    - 
    - When TEAM_MODE=false AND resume detected: existing v2.1.0 resume behavior unchanged
 
-**7. Feature Branch Creation**
+**7. TRD Staleness Gate**
+   Check TRD freshness before committing to a feature branch. Skip on resume.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - If resume was detected in Preflight step 6 (ROOT_EPIC_ID is set / IS_RESUME=true): skip this step — staleness check does not apply to resuming an existing scaffold. Print 'Staleness check: skipped (resume detected)' and continue to step 8.
+   - If first invocation (IS_RESUME=false / no ROOT_EPIC_ID found in step 6): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 4 and IS_RESUME=false.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill (TRD fresh or successfully refined): continue to Preflight step 8 (Feature Branch Creation).
+
+**8. Feature Branch Creation**
    Create or switch to feature branch for TRD implementation
 
    - branch_prefix = 'pr' if PR_FORMAT=true else 'phase'; branch_name = 'feature/<TRD_SLUG>-<branch_prefix>-1'; CURRENT_PHASE_BRANCH = branch_name; PHASE_BRANCH_MAP = {1: branch_name}; PHASE_PR_MAP = {}
@@ -152,13 +162,13 @@ Key behaviors:
    - If exists: git switch <branch_name>
    - If not exists: git town hack <branch_name> (fallback: git switch -c <branch_name>)
 
-**8. Strategy Detection**
+**9. Strategy Detection**
    Determine implementation strategy from arguments, TRD content, or auto-detection
 
    - Priority: $ARGUMENTS strategy=X -> TRD explicit -> constitution -> auto-detect -> default (tdd)
    - Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
 
-**9. Team Configuration Detection**
+**10. Team Configuration Detection**
    Determine team mode using precedence order: (1) TRD ## Team Configuration section,
 (2) command YAML team: section, (3) no team (single-agent). Sets TEAM_MODE,
 TEAM_CONFIG_SOURCE, TEAM_ROLES, REVIEWER_ENABLED, and QA_ENABLED for all subsequent
@@ -249,7 +259,7 @@ FR-5.1, FR-5.2, FR-5.3, FR-5.4, FR-5.5, FR-5.6, NFR-1.3, NFR-4.2
    -   - Identical to Case 3
    - Record which steps are skipped in the team configuration summary printed during this Preflight step.
 
-**10. Marketplace Preflight Check**
+**11. Marketplace Preflight Check**
    Before execution begins, check for marketplace capability gaps that may affect team
 config quality. Presents suggestions for missing agents/skills and installs approved
 plugins. Re-reads team config from TRD after installation if agents referenced in TRD
@@ -276,7 +286,7 @@ team config are now available. AC: FR-11.1 through FR-11.6, AC-8.1 through AC-8.
    -   If newly installed agents are NOT referenced in TRD team config: log 'Note: newly installed agents not referenced in TRD team config. Consider re-running /create-trd to update team configuration.'
    - Step 8 — If user declines all suggestions: proceed with existing team config and available agents
 
-**11. Traceability Validation Gate**
+**12. Traceability Validation Gate**
    Run validate-requirements as an automatic preflight gate before scaffolding begins.
 Checks that PRD requirements have TRD task coverage, that [satisfies] annotations
 reference real REQ-NNN IDs, and that every user-facing task has a paired -TEST task.

--- a/packages/development/commands/ensemble/implement-trd.md
+++ b/packages/development/commands/ensemble/implement-trd.md
@@ -27,7 +27,19 @@ development including planning, implementation, testing, and quality gates.
    - If validation fails, escalate with specific error message
    - Ensure clean working directory (git status)
 
-**2. Feature Branch Creation**
+**2. TRD Staleness Gate**
+   Check TRD freshness before creating a feature branch. Skip if branch already exists (resume).
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+
+   - Derive TRD_PATH from $ARGUMENTS (the .md path argument).
+   - Derive TRD_SLUG from TRD_PATH filename (lowercase, replace non-alphanumeric with hyphens).
+   - Resume detection: run 'git branch --list feature/<TRD_SLUG>-sprint-1'. If this returns a branch name: IS_RESUME=true. If empty: IS_RESUME=false.
+   - Execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH and IS_RESUME.
+   - On HALT from skill: do not proceed. Implementation stops.
+   - On RETURN from skill: continue to step 3 (Feature Branch Creation).
+
+**3. Feature Branch Creation**
    Create sprint-1 feature branch using git-town skill interview template
 
    - Load interview template from packages/git/skills/git-town/templates/interview-branch-creation.md
@@ -38,13 +50,13 @@ development including planning, implementation, testing, and quality gates.
    - Execute - git-town hack feature/<trd-slug>-sprint-1 --parent <base-branch>
    - Verify branch creation successful (check git branch output)
 
-**3. TRD Ingestion**
+**4. TRD Ingestion**
    Parse and analyze existing TRD document with checkbox tracking
 
-**4. Technical Feasibility Review**
+**5. Technical Feasibility Review**
    Validate implementation approach and architecture
 
-**5. Resource Assessment**
+**6. Resource Assessment**
    Identify required specialist agents and tools
 
 ### Phase 2: Ensemble Orchestrator Delegation

--- a/packages/development/commands/implement-trd-beads.yaml
+++ b/packages/development/commands/implement-trd-beads.yaml
@@ -275,6 +275,17 @@ workflow:
             - "When TEAM_MODE=false AND resume detected: existing v2.1.0 resume behavior unchanged"
 
         - order: 7
+          title: TRD Staleness Gate
+          description: |
+            Check TRD freshness before committing to a feature branch. Skip on resume.
+            Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+          actions:
+            - "If resume was detected in Preflight step 6 (ROOT_EPIC_ID is set / IS_RESUME=true): skip this step — staleness check does not apply to resuming an existing scaffold. Print 'Staleness check: skipped (resume detected)' and continue to step 8."
+            - "If first invocation (IS_RESUME=false / no ROOT_EPIC_ID found in step 6): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 4 and IS_RESUME=false."
+            - "On HALT from skill: do not proceed. Implementation stops."
+            - "On RETURN from skill (TRD fresh or successfully refined): continue to Preflight step 8 (Feature Branch Creation)."
+
+        - order: 8
           title: Feature Branch Creation
           description: Create or switch to feature branch for TRD implementation
           actions:
@@ -283,14 +294,14 @@ workflow:
             - "If exists: git switch <branch_name>"
             - "If not exists: git town hack <branch_name> (fallback: git switch -c <branch_name>)"
 
-        - order: 8
+        - order: 9
           title: Strategy Detection
           description: Determine implementation strategy from arguments, TRD content, or auto-detection
           actions:
             - "Priority: $ARGUMENTS strategy=X -> TRD explicit -> constitution -> auto-detect -> default (tdd)"
             - "Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd"
 
-        - order: 9
+        - order: 10
           title: Team Configuration Detection
           description: |
             Determine team mode using precedence order: (1) TRD ## Team Configuration section,
@@ -382,7 +393,7 @@ workflow:
             - "  - Identical to Case 3"
             - "Record which steps are skipped in the team configuration summary printed during this Preflight step."
 
-        - order: 10
+        - order: 11
           title: Marketplace Preflight Check
           description: |
             Before execution begins, check for marketplace capability gaps that may affect team
@@ -410,7 +421,7 @@ workflow:
             - "  If newly installed agents are NOT referenced in TRD team config: log 'Note: newly installed agents not referenced in TRD team config. Consider re-running /create-trd to update team configuration.'"
             - "Step 8 — If user declines all suggestions: proceed with existing team config and available agents"
 
-        - order: 11
+        - order: 12
           title: Traceability Validation Gate
           description: |
             Run validate-requirements as an automatic preflight gate before scaffolding begins.

--- a/packages/development/commands/implement-trd.yaml
+++ b/packages/development/commands/implement-trd.yaml
@@ -30,6 +30,19 @@ workflow:
             - Ensure clean working directory (git status)
         
         - order: 2
+          title: TRD Staleness Gate
+          description: |
+            Check TRD freshness before creating a feature branch. Skip if branch already exists (resume).
+            Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+          actions:
+            - "Derive TRD_PATH from $ARGUMENTS (the .md path argument)."
+            - "Derive TRD_SLUG from TRD_PATH filename (lowercase, replace non-alphanumeric with hyphens)."
+            - "Resume detection: run 'git branch --list feature/<TRD_SLUG>-sprint-1'. If this returns a branch name: IS_RESUME=true. If empty: IS_RESUME=false."
+            - "Execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH and IS_RESUME."
+            - "On HALT from skill: do not proceed. Implementation stops."
+            - "On RETURN from skill: continue to step 3 (Feature Branch Creation)."
+
+        - order: 3
           title: Feature Branch Creation
           description: Create sprint-1 feature branch using git-town skill interview template
           actions:
@@ -40,16 +53,16 @@ workflow:
             - Set base_branch to main (or current default branch)
             - Execute - git-town hack feature/<trd-slug>-sprint-1 --parent <base-branch>
             - Verify branch creation successful (check git branch output)
-        
-        - order: 3
+
+        - order: 4
           title: TRD Ingestion
           description: Parse and analyze existing TRD document with checkbox tracking
         
-        - order: 4
+        - order: 5
           title: Technical Feasibility Review
           description: Validate implementation approach and architecture
-        
-        - order: 5
+
+        - order: 6
           title: Resource Assessment
           description: Identify required specialist agents and tools
     

--- a/packages/development/skills/staleness-gate/SKILL.md
+++ b/packages/development/skills/staleness-gate/SKILL.md
@@ -1,0 +1,205 @@
+# TRD Staleness Gate
+
+Detect whether a TRD is stale before implementation begins. If stale, invoke
+`/ensemble:refine-trd` to refresh it, then proceed. If refinement fails, halt.
+
+---
+
+## Inputs
+
+| Variable    | Type    | Description |
+|-------------|---------|-------------|
+| `TRD_PATH`  | string  | Absolute or repo-relative path to the TRD `.md` file |
+| `IS_RESUME` | boolean | `true` when implementation is resuming an existing scaffold; `false` on first invocation |
+| `FLAVOR`    | string  | Calling command name (for diagnostic messages): `implement-trd-beads`, `implement-trd`, or `beads-build` |
+
+---
+
+## Resume Detection by Flavor
+
+| Flavor | `IS_RESUME = true` when |
+|--------|------------------------|
+| `implement-trd-beads` | `ROOT_EPIC_ID` found in `br list --json` for this TRD slug (Preflight step 6 — Resume Detection) |
+| `implement-trd` | `git branch --list feature/<TRD_SLUG>-sprint-1` returns a branch name (checked before branch creation) |
+| `beads-build --trd` | `ROOT_EPIC_ID` found in Epic Discovery step (Preflight step 4) |
+
+---
+
+## Algorithm
+
+### Step 1 — Resume Check
+
+```
+IF IS_RESUME == true:
+    print "Staleness check: skipped (resume detected)"
+    RETURN
+```
+
+Staleness detection does not apply to resuming an existing scaffold. The TRD was
+already validated on first invocation; checking it again mid-session would block
+legitimate resume operations.
+
+---
+
+### Step 2 — Get TRD mtime
+
+Determine the last-modified time of the TRD file as a Unix epoch integer.
+
+```bash
+# macOS
+TRD_MTIME=$(stat -f %m "<TRD_PATH>")
+
+# Linux
+TRD_MTIME=$(stat -c %Y "<TRD_PATH>")
+
+# Fallback (cross-platform, if stat not available or fails)
+TRD_MTIME=$(python3 -c "import os; print(int(os.path.getmtime('<TRD_PATH>')))")
+```
+
+Try macOS form first; if it fails (non-zero exit or empty output), try Linux form;
+if that fails, try the Python fallback.
+
+```
+IF all three methods fail:
+    print "WARNING: Cannot determine TRD file age — skipping staleness check."
+    RETURN
+```
+
+---
+
+### Step 3 — Age Check
+
+```bash
+CURRENT_TIME=$(date +%s)
+AGE_SECONDS=$(( CURRENT_TIME - TRD_MTIME ))
+AGE_HOURS=$(( AGE_SECONDS / 3600 ))
+```
+
+```
+IF AGE_HOURS > 24:
+    STALE_AGE=true
+ELSE:
+    STALE_AGE=false
+```
+
+The threshold is 24 hours. A TRD created more than 24 hours ago may no longer
+accurately reflect the current state of the codebase.
+
+---
+
+### Step 4 — Source File Drift Check
+
+**This step ALWAYS runs, even if `STALE_AGE=true`.** Both conditions are evaluated
+independently so the staleness message can report both age and drift when both apply.
+
+List all tracked source files (respecting `.gitignore`) and exclude generated
+artifacts that do not constitute meaningful code drift:
+
+```bash
+git ls-files --exclude-standard \
+  | grep -vE "^packages/[^/]+/commands/ensemble/|^packages/pi/prompts/|^packages/codex/\.codex/"
+```
+
+**Exclusion rationale:**
+
+| Excluded pattern | Reason |
+|-----------------|--------|
+| `packages/*/commands/ensemble/` | Generated markdown command files — updated by `npm run generate` after YAML edits; not meaningful drift |
+| `packages/pi/prompts/` | Generated pi prompt files |
+| `packages/codex/.codex/` | Generated codex skill files |
+| Any path in `.gitignore` | Covered by `--exclude-standard`: `dist/`, `build/`, `node_modules/`, `coverage/`, `.beads.bd/`, `.bv/`, `.ntm/`, `.opencode/`, `.dolt/` |
+
+For each file in the filtered list, retrieve its mtime (same platform-aware stat
+as Step 2). Collect all files where `file_mtime > TRD_MTIME`:
+
+```
+NEWER_FILES = [ file for file in filtered_list if mtime(file) > TRD_MTIME ]
+NEWER_COUNT = len(NEWER_FILES)
+
+IF NEWER_COUNT > 0:
+    STALE_DRIFT=true
+ELSE:
+    STALE_DRIFT=false
+```
+
+---
+
+### Step 5 — Gate Decision
+
+```
+STALE = (STALE_AGE OR STALE_DRIFT)
+```
+
+**If not stale:**
+
+```
+print "Staleness check: TRD is current"
+RETURN
+```
+
+**If stale:** build a combined diagnostic message and invoke refinement.
+
+Message construction:
+
+```
+MESSAGE = ""
+
+IF STALE_AGE:
+    MESSAGE += "TRD is ${AGE_HOURS}h old (threshold: 24h).\n"
+
+IF STALE_DRIFT:
+    MESSAGE += "${NEWER_COUNT} source file(s) are newer than the TRD:\n"
+    FOR file IN NEWER_FILES[0:10]:
+        MESSAGE += "  - ${file}\n"
+    IF NEWER_COUNT > 10:
+        MESSAGE += "  (and ${NEWER_COUNT - 10} more)\n"
+
+MESSAGE += "Running /ensemble:refine-trd before implementation."
+```
+
+Print the message, then invoke:
+
+```
+/ensemble:refine-trd <TRD_PATH>
+```
+
+---
+
+### Step 6 — Post-Refinement Decision
+
+```
+IF refine-trd exits 0:
+    print "Staleness gate satisfied — TRD refreshed. Proceeding with implementation."
+    RETURN
+    # No re-check: the refinement is trusted. A second staleness check would create
+    # an infinite loop if the refine-trd command itself touches source files.
+
+IF refine-trd exits non-zero:
+    print "STALENESS GATE FAILURE: TRD refinement failed. Fix the TRD manually and re-run."
+    HALT
+```
+
+**RETURN** means: resume execution at the next Preflight step in the calling command.  
+**HALT** means: do not proceed with any implementation. The calling command stops.
+
+---
+
+## Known Limitation
+
+**Git clone/checkout resets file mtimes.**
+
+After `git clone`, `git checkout`, or `git pull`, all files receive the current
+wall-clock time as their mtime. This means:
+
+- A freshly-cloned repository will show all files as "newer than" the TRD — even
+  if no actual changes were made relative to the TRD's last update.
+- Checking out an old branch on a recent working tree will not reliably detect
+  semantic staleness introduced by the branch switch.
+
+This limitation is accepted and documented in PRD-2026-022 non-goals. Semantic
+staleness detection (git log-based, content-aware) is out of scope for this release.
+
+**Workaround:** If you encounter false-positive staleness after a fresh clone,
+either run `/ensemble:refine-trd` manually (it will confirm the TRD is current and
+re-touch its mtime), or proceed past the gate — the refinement step is designed to
+be safe to run even when the TRD is already accurate.

--- a/packages/pi/prompts/ensemble-beads-build.md
+++ b/packages/pi/prompts/ensemble-beads-build.md
@@ -64,7 +64,20 @@ Validate TRD file and build traceability map when TRD_MODE is enabled
 9. Classify task type: if task.id ends in -TEST suffix, mark is_test_task=true; extract verifies_task_id and satisfies_req_id; store in TASK_TRACEABILITY[task.id]
 10. Print "TRD augmentations: enabled (traceability, checkbox sync, requirement report)"
 
-### Step 6: Strategy Detection
+### Step 6: TRD Staleness Gate
+
+When TRD_MODE=true and first invocation, check TRD freshness before execution begins.
+Skip when TRD_MODE=false or when resuming an existing epic.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+**Actions:**
+1. If TRD_MODE=false: skip this step entirely. Print "Staleness check: skipped (no --trd flag)" and continue to step 7.
+2. If TRD_MODE=true AND ROOT_EPIC_ID was found in Preflight step 4 (Epic Discovery) — IS_RESUME=true: skip this step. Print "Staleness check: skipped (resume detected)" and continue to step 7.
+3. If TRD_MODE=true AND no ROOT_EPIC_ID found in step 4 (first invocation): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 1 and IS_RESUME=false.
+4. On HALT from skill: do not proceed. Implementation stops.
+5. On RETURN from skill: continue to step 7 (Strategy Detection).
+
+### Step 7: Strategy Detection
 
 Determine implementation strategy from arguments, TRD content, or auto-detection
 
@@ -73,7 +86,7 @@ Determine implementation strategy from arguments, TRD content, or auto-detection
 2. Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
 3. Store STRATEGY; print "Strategy: <STRATEGY>"
 
-### Step 7: Team Configuration Detection
+### Step 8: Team Configuration Detection
 
 Detect team configuration from --team-config argument or bead metadata, default to single-agent
 

--- a/packages/pi/prompts/ensemble-implement-trd-beads.md
+++ b/packages/pi/prompts/ensemble-implement-trd-beads.md
@@ -126,7 +126,18 @@ Check for existing beads scaffold to enable cross-session resume
 39. 
 40. When TEAM_MODE=false AND resume detected: existing v2.1.0 resume behavior unchanged
 
-### Step 7: Feature Branch Creation
+### Step 7: TRD Staleness Gate
+
+Check TRD freshness before committing to a feature branch. Skip on resume.
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+**Actions:**
+1. If resume was detected in Preflight step 6 (ROOT_EPIC_ID is set / IS_RESUME=true): skip this step — staleness check does not apply to resuming an existing scaffold. Print 'Staleness check: skipped (resume detected)' and continue to step 8.
+2. If first invocation (IS_RESUME=false / no ROOT_EPIC_ID found in step 6): execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH from Preflight step 4 and IS_RESUME=false.
+3. On HALT from skill: do not proceed. Implementation stops.
+4. On RETURN from skill (TRD fresh or successfully refined): continue to Preflight step 8 (Feature Branch Creation).
+
+### Step 8: Feature Branch Creation
 
 Create or switch to feature branch for TRD implementation
 
@@ -136,7 +147,7 @@ Create or switch to feature branch for TRD implementation
 3. If exists: git switch <branch_name>
 4. If not exists: git town hack <branch_name> (fallback: git switch -c <branch_name>)
 
-### Step 8: Strategy Detection
+### Step 9: Strategy Detection
 
 Determine implementation strategy from arguments, TRD content, or auto-detection
 
@@ -144,7 +155,7 @@ Determine implementation strategy from arguments, TRD content, or auto-detection
 1. Priority: $ARGUMENTS strategy=X -> TRD explicit -> constitution -> auto-detect -> default (tdd)
 2. Auto-detect: legacy/brownfield/untested -> characterization; bug fix/regression -> bug-fix; refactor/tech debt -> refactor; prototype/spike/POC -> test-after; default -> tdd
 
-### Step 9: Team Configuration Detection
+### Step 10: Team Configuration Detection
 
 Determine team mode using precedence order: (1) TRD ## Team Configuration section,
 (2) command YAML team: section, (3) no team (single-agent). Sets TEAM_MODE,
@@ -236,7 +247,7 @@ FR-5.1, FR-5.2, FR-5.3, FR-5.4, FR-5.5, FR-5.6, NFR-1.3, NFR-4.2
 81. - Identical to Case 3
 82. Record which steps are skipped in the team configuration summary printed during this Preflight step.
 
-### Step 10: Marketplace Preflight Check
+### Step 11: Marketplace Preflight Check
 
 Before execution begins, check for marketplace capability gaps that may affect team
 config quality. Presents suggestions for missing agents/skills and installs approved
@@ -264,7 +275,7 @@ team config are now available. AC: FR-11.1 through FR-11.6, AC-8.1 through AC-8.
 18. If newly installed agents are NOT referenced in TRD team config: log 'Note: newly installed agents not referenced in TRD team config. Consider re-running /create-trd to update team configuration.'
 19. Step 8 — If user declines all suggestions: proceed with existing team config and available agents
 
-### Step 11: Traceability Validation Gate
+### Step 12: Traceability Validation Gate
 
 Run validate-requirements as an automatic preflight gate before scaffolding begins.
 Checks that PRD requirements have TRD task coverage, that [satisfies] annotations

--- a/packages/pi/prompts/ensemble-implement-trd.md
+++ b/packages/pi/prompts/ensemble-implement-trd.md
@@ -18,7 +18,20 @@ Check git-town installation and configuration using validation script
 3. If validation fails, escalate with specific error message
 4. Ensure clean working directory (git status)
 
-### Step 2: Feature Branch Creation
+### Step 2: TRD Staleness Gate
+
+Check TRD freshness before creating a feature branch. Skip if branch already exists (resume).
+Algorithm defined in packages/development/skills/staleness-gate/SKILL.md.
+
+**Actions:**
+1. Derive TRD_PATH from $ARGUMENTS (the .md path argument).
+2. Derive TRD_SLUG from TRD_PATH filename (lowercase, replace non-alphanumeric with hyphens).
+3. Resume detection: run 'git branch --list feature/<TRD_SLUG>-sprint-1'. If this returns a branch name: IS_RESUME=true. If empty: IS_RESUME=false.
+4. Execute the TRD Staleness Gate per packages/development/skills/staleness-gate/SKILL.md using TRD_PATH and IS_RESUME.
+5. On HALT from skill: do not proceed. Implementation stops.
+6. On RETURN from skill: continue to step 3 (Feature Branch Creation).
+
+### Step 3: Feature Branch Creation
 
 Create sprint-1 feature branch using git-town skill interview template
 
@@ -31,15 +44,15 @@ Create sprint-1 feature branch using git-town skill interview template
 6. Execute - git-town hack feature/<trd-slug>-sprint-1 --parent <base-branch>
 7. Verify branch creation successful (check git branch output)
 
-### Step 3: TRD Ingestion
+### Step 4: TRD Ingestion
 
 Parse and analyze existing TRD document with checkbox tracking
 
-### Step 4: Technical Feasibility Review
+### Step 5: Technical Feasibility Review
 
 Validate implementation approach and architecture
 
-### Step 5: Resource Assessment
+### Step 6: Resource Assessment
 
 Identify required specialist agents and tools
 

--- a/packages/pi/skills/staleness-gate/SKILL.md
+++ b/packages/pi/skills/staleness-gate/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: staleness-gate
+description: 'Detect whether a TRD is stale before implementation begins. If stale, invoke'
+---
+# TRD Staleness Gate
+
+Detect whether a TRD is stale before implementation begins. If stale, invoke
+`/ensemble:refine-trd` to refresh it, then proceed. If refinement fails, halt.
+
+---
+
+## Inputs
+
+| Variable    | Type    | Description |
+|-------------|---------|-------------|
+| `TRD_PATH`  | string  | Absolute or repo-relative path to the TRD `.md` file |
+| `IS_RESUME` | boolean | `true` when implementation is resuming an existing scaffold; `false` on first invocation |
+| `FLAVOR`    | string  | Calling command name (for diagnostic messages): `implement-trd-beads`, `implement-trd`, or `beads-build` |
+
+---
+
+## Resume Detection by Flavor
+
+| Flavor | `IS_RESUME = true` when |
+|--------|------------------------|
+| `implement-trd-beads` | `ROOT_EPIC_ID` found in `br list --json` for this TRD slug (Preflight step 6 — Resume Detection) |
+| `implement-trd` | `git branch --list feature/<TRD_SLUG>-sprint-1` returns a branch name (checked before branch creation) |
+| `beads-build --trd` | `ROOT_EPIC_ID` found in Epic Discovery step (Preflight step 4) |
+
+---
+
+## Algorithm
+
+### Step 1 — Resume Check
+
+```
+IF IS_RESUME == true:
+    print "Staleness check: skipped (resume detected)"
+    RETURN
+```
+
+Staleness detection does not apply to resuming an existing scaffold. The TRD was
+already validated on first invocation; checking it again mid-session would block
+legitimate resume operations.
+
+---
+
+### Step 2 — Get TRD mtime
+
+Determine the last-modified time of the TRD file as a Unix epoch integer.
+
+```bash
+# macOS
+TRD_MTIME=$(stat -f %m "<TRD_PATH>")
+
+# Linux
+TRD_MTIME=$(stat -c %Y "<TRD_PATH>")
+
+# Fallback (cross-platform, if stat not available or fails)
+TRD_MTIME=$(python3 -c "import os; print(int(os.path.getmtime('<TRD_PATH>')))")
+```
+
+Try macOS form first; if it fails (non-zero exit or empty output), try Linux form;
+if that fails, try the Python fallback.
+
+```
+IF all three methods fail:
+    print "WARNING: Cannot determine TRD file age — skipping staleness check."
+    RETURN
+```
+
+---
+
+### Step 3 — Age Check
+
+```bash
+CURRENT_TIME=$(date +%s)
+AGE_SECONDS=$(( CURRENT_TIME - TRD_MTIME ))
+AGE_HOURS=$(( AGE_SECONDS / 3600 ))
+```
+
+```
+IF AGE_HOURS > 24:
+    STALE_AGE=true
+ELSE:
+    STALE_AGE=false
+```
+
+The threshold is 24 hours. A TRD created more than 24 hours ago may no longer
+accurately reflect the current state of the codebase.
+
+---
+
+### Step 4 — Source File Drift Check
+
+**This step ALWAYS runs, even if `STALE_AGE=true`.** Both conditions are evaluated
+independently so the staleness message can report both age and drift when both apply.
+
+List all tracked source files (respecting `.gitignore`) and exclude generated
+artifacts that do not constitute meaningful code drift:
+
+```bash
+git ls-files --exclude-standard \
+  | grep -vE "^packages/[^/]+/commands/ensemble/|^packages/pi/prompts/|^packages/codex/\.codex/"
+```
+
+**Exclusion rationale:**
+
+| Excluded pattern | Reason |
+|-----------------|--------|
+| `packages/*/commands/ensemble/` | Generated markdown command files — updated by `npm run generate` after YAML edits; not meaningful drift |
+| `packages/pi/prompts/` | Generated pi prompt files |
+| `packages/codex/.codex/` | Generated codex skill files |
+| Any path in `.gitignore` | Covered by `--exclude-standard`: `dist/`, `build/`, `node_modules/`, `coverage/`, `.beads.bd/`, `.bv/`, `.ntm/`, `.opencode/`, `.dolt/` |
+
+For each file in the filtered list, retrieve its mtime (same platform-aware stat
+as Step 2). Collect all files where `file_mtime > TRD_MTIME`:
+
+```
+NEWER_FILES = [ file for file in filtered_list if mtime(file) > TRD_MTIME ]
+NEWER_COUNT = len(NEWER_FILES)
+
+IF NEWER_COUNT > 0:
+    STALE_DRIFT=true
+ELSE:
+    STALE_DRIFT=false
+```
+
+---
+
+### Step 5 — Gate Decision
+
+```
+STALE = (STALE_AGE OR STALE_DRIFT)
+```
+
+**If not stale:**
+
+```
+print "Staleness check: TRD is current"
+RETURN
+```
+
+**If stale:** build a combined diagnostic message and invoke refinement.
+
+Message construction:
+
+```
+MESSAGE = ""
+
+IF STALE_AGE:
+    MESSAGE += "TRD is ${AGE_HOURS}h old (threshold: 24h).\n"
+
+IF STALE_DRIFT:
+    MESSAGE += "${NEWER_COUNT} source file(s) are newer than the TRD:\n"
+    FOR file IN NEWER_FILES[0:10]:
+        MESSAGE += "  - ${file}\n"
+    IF NEWER_COUNT > 10:
+        MESSAGE += "  (and ${NEWER_COUNT - 10} more)\n"
+
+MESSAGE += "Running /ensemble:refine-trd before implementation."
+```
+
+Print the message, then invoke:
+
+```
+/ensemble:refine-trd <TRD_PATH>
+```
+
+---
+
+### Step 6 — Post-Refinement Decision
+
+```
+IF refine-trd exits 0:
+    print "Staleness gate satisfied — TRD refreshed. Proceeding with implementation."
+    RETURN
+    # No re-check: the refinement is trusted. A second staleness check would create
+    # an infinite loop if the refine-trd command itself touches source files.
+
+IF refine-trd exits non-zero:
+    print "STALENESS GATE FAILURE: TRD refinement failed. Fix the TRD manually and re-run."
+    HALT
+```
+
+**RETURN** means: resume execution at the next Preflight step in the calling command.  
+**HALT** means: do not proceed with any implementation. The calling command stops.
+
+---
+
+## Known Limitation
+
+**Git clone/checkout resets file mtimes.**
+
+After `git clone`, `git checkout`, or `git pull`, all files receive the current
+wall-clock time as their mtime. This means:
+
+- A freshly-cloned repository will show all files as "newer than" the TRD — even
+  if no actual changes were made relative to the TRD's last update.
+- Checking out an old branch on a recent working tree will not reliably detect
+  semantic staleness introduced by the branch switch.
+
+This limitation is accepted and documented in PRD-2026-022 non-goals. Semantic
+staleness detection (git log-based, content-aware) is out of scope for this release.
+
+**Workaround:** If you encounter false-positive staleness after a fresh clone,
+either run `/ensemble:refine-trd` manually (it will confirm the TRD is current and
+re-touch its mtime), or proceed past the gate — the refinement step is designed to
+be safe to run even when the TRD is already accurate.


### PR DESCRIPTION
## Summary

- Adds `packages/development/skills/staleness-gate/SKILL.md` — canonical staleness detection algorithm (mtime age check >24h, source file drift check, auto-invoke `/ensemble:refine-trd` on detection, resume skip logic, known limitation documented)
- Adds TRD Staleness Gate Preflight step to `implement-trd-beads.yaml` (new step 7; steps 7-11 renumbered to 8-12)
- Adds TRD Staleness Gate Preflight step to `implement-trd.yaml` (new step 2; steps 2-5 renumbered to 3-6)
- Adds TRD Staleness Gate Preflight step to `beads-build.yaml` (new step 6; steps 6-7 renumbered to 7-8)
- Regenerates all downstream artifacts (markdown commands, pi prompts, codex skills)

**Shippable State:** All three `implement-trd` flavors enforce the staleness gate on first invocation — no implementation starts against a TRD older than 24 hours or with newer source files; resume paths are unaffected.

**TRD:** docs/TRD/TRD-2026-023-trd-staleness-gate.md
**Design Readiness Score:** 4.88 (PASS)

## Beads

- Root epic: `ensemble-pvm9` (closed)
- PR 1 story: `ensemble-4v8b` (closed)
- TRD-001 `ensemble-qec3` (closed) — SKILL.md created
- TRD-001-TEST `ensemble-aoqh` (closed) — SKILL.md verified
- TRD-002 `ensemble-8283` (closed) — implement-trd-beads.yaml updated
- TRD-002-TEST `ensemble-fy4c` (closed) — beads yaml verified
- TRD-003 `ensemble-sb4e` (closed) — implement-trd.yaml updated
- TRD-003-TEST `ensemble-nbn6` (closed) — implement-trd yaml verified
- TRD-004 `ensemble-gula` (closed) — beads-build.yaml updated
- TRD-004-TEST `ensemble-z8i2` (closed) — beads-build yaml verified
- TRD-005 `ensemble-d0ml` (closed) — artifacts regenerated

## Test plan

- [ ] `npm run validate` exits 0 (verified in CI)
- [ ] implement-trd-beads.yaml Preflight steps 1-12 sequential, step 7 = TRD Staleness Gate, step 8 = Feature Branch Creation, step 12 = Traceability Validation Gate
- [ ] implement-trd.yaml Preflight steps 1-6 sequential, step 2 = TRD Staleness Gate, step 3 = Feature Branch Creation
- [ ] beads-build.yaml Preflight steps 1-8 sequential, step 6 = TRD Staleness Gate, step 7 = Strategy Detection
- [ ] SKILL.md documents all 6 algorithm steps, both stat variants, exclusion list, truncation at 10, no-recheck post-refinement, Known Limitation section
- [ ] All resume paths preserved: IS_RESUME=true skips gate for all three flavors
- [ ] beads-build TRD_MODE=false path skips gate with correct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)