### PR TITLE
fix(development): restore phase-strict gating silently disabled by an option rename

### DIFF
--- a/packages/development/lib/complete-beads-planner.js
+++ b/packages/development/lib/complete-beads-planner.js
@@ -316,17 +316,33 @@ function planDispatch(
 function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, prFormat) {
   if (!prFormat) return { passed: orderedIds, deferred: [] };
 
-  // Step 7's caller says "if TRD phase metadata present" — but nothing enforced
-  // it, and the CLI turns a missing phase file into `{}` (complete-beads-cli.js:
-  // `phaseTaskIdsJson || {}`). With the gate live and an empty map, selectNextTasks'
-  // currentPhase() returns null and EVERY ready bead is deferred as 'phase-gate':
-  // a total stall, reported as "waiting on an earlier phase", exiting 0. That is
-  // the same silent-failure this fix exists to remove, one level up.
+  // prFormat is set by trd-parser ONLY when the TRD has `PR N:` headings
+  // (trd-parser.js: `if (sawPR) { prFormat = true; ... }`), and a PR heading
+  // always produces at least one phase. So prFormat with no usable phase task
+  // ids is not "a TRD without phases" — it can only mean the phase map failed
+  // to load. complete-beads-cli turns an absent or unreadable file into `{}`
+  // (`phaseTaskIdsJson || {}`), which is exactly how that state arrives here.
   //
-  // No phase metadata means no phase boundaries to enforce, so the gate does not
-  // apply and the ids pass through — but say so on stderr, because a TRD that
-  // SHOULD have phases and silently lost them looks identical to one that never
-  // had them, and the difference decides whether the run is correct.
+  // Fail CLOSED. An earlier version of this guard passed the ids through with a
+  // warning; that fails open on the one condition it was written to detect,
+  // silently dispatching later-phase work across a real boundary. planDispatch
+  // already signals unusable input by throwing, so throw.
+  //
+  // Count TASK IDS, not phase keys: buildPhaseTaskIds keeps empty phases on the
+  // parse path, so {"1":[],"2":[]} has two keys and zero ids. Counting keys let
+  // that shape skip the guard, currentPhase() returned null, and every ready
+  // bead was deferred 'phase-gate' — the same total stall, still reachable.
+  const phaseIdCount = phaseTaskIds
+    ? Object.values(phaseTaskIds).reduce((n, ids) => n + (Array.isArray(ids) ? ids.length : 0), 0)
+    : 0;
+  if (phaseIdCount === 0) {
+    throw new Error(
+      'complete-beads-planner: --pr-format set but the TRD phase map contains no task ids. ' +
+        'A PR-format TRD always has at least one phase, so this means the phase map failed to ' +
+        'load (missing/unreadable --phase-task-ids, or a map whose phases are all empty). ' +
+        'Refusing to dispatch: phase-strict gating cannot be enforced without it.'
+    );
+  }
 
   // Extract task IDs from all closed beads for accurate currentPhase detection
   const phaseCount = phaseTaskIds ? Object.keys(phaseTaskIds).length : 0;

--- a/packages/development/lib/complete-beads-planner.js
+++ b/packages/development/lib/complete-beads-planner.js
@@ -332,8 +332,18 @@ function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, pr
   // parse path, so {"1":[],"2":[]} has two keys and zero ids. Counting keys let
   // that shape skip the guard, currentPhase() returned null, and every ready
   // bead was deferred 'phase-gate' — the same total stall, still reachable.
+  // Count ids only under NUMERIC keys. phase-tracker's sortedPhaseNumbers drops
+  // non-finite keys, so ids parked under e.g. "a" are invisible to currentPhase()
+  // — counting them would pass the guard and then stall on exactly the shape the
+  // guard exists to catch. buildPhaseTaskIds/reconstructPhaseTaskIds only emit
+  // numeric keys, so this bites only a hand-edited or corrupted map; that is
+  // precisely when a loud failure beats a silent one.
   const phaseIdCount = phaseTaskIds
-    ? Object.values(phaseTaskIds).reduce((n, ids) => n + (Array.isArray(ids) ? ids.length : 0), 0)
+    ? Object.entries(phaseTaskIds).reduce(
+        (n, [key, ids]) =>
+          n + (Number.isFinite(Number(key)) && Array.isArray(ids) ? ids.length : 0),
+        0
+      )
     : 0;
   if (phaseIdCount === 0) {
     throw new Error(
@@ -345,16 +355,6 @@ function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, pr
   }
 
   // Extract task IDs from all closed beads for accurate currentPhase detection
-  const phaseCount = phaseTaskIds ? Object.keys(phaseTaskIds).length : 0;
-  if (phaseCount === 0) {
-    process.stderr.write(
-      'WARN complete-beads-planner: --pr-format set but no TRD phase metadata; ' +
-        'phase-strict gating does not apply and all ready beads pass through. ' +
-        'If this TRD has phases, the phase map failed to load.\n'
-    );
-    return { passed: orderedIds, deferred: [] };
-  }
-
   const closedSet = closedTaskIdSet(closedBeads);
   const closedTaskIds = [...closedSet];
 

--- a/packages/development/lib/complete-beads-planner.js
+++ b/packages/development/lib/complete-beads-planner.js
@@ -316,7 +316,29 @@ function planDispatch(
 function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, prFormat) {
   if (!prFormat) return { passed: orderedIds, deferred: [] };
 
+  // Step 7's caller says "if TRD phase metadata present" — but nothing enforced
+  // it, and the CLI turns a missing phase file into `{}` (complete-beads-cli.js:
+  // `phaseTaskIdsJson || {}`). With the gate live and an empty map, selectNextTasks'
+  // currentPhase() returns null and EVERY ready bead is deferred as 'phase-gate':
+  // a total stall, reported as "waiting on an earlier phase", exiting 0. That is
+  // the same silent-failure this fix exists to remove, one level up.
+  //
+  // No phase metadata means no phase boundaries to enforce, so the gate does not
+  // apply and the ids pass through — but say so on stderr, because a TRD that
+  // SHOULD have phases and silently lost them looks identical to one that never
+  // had them, and the difference decides whether the run is correct.
+
   // Extract task IDs from all closed beads for accurate currentPhase detection
+  const phaseCount = phaseTaskIds ? Object.keys(phaseTaskIds).length : 0;
+  if (phaseCount === 0) {
+    process.stderr.write(
+      'WARN complete-beads-planner: --pr-format set but no TRD phase metadata; ' +
+        'phase-strict gating does not apply and all ready beads pass through. ' +
+        'If this TRD has phases, the phase map failed to load.\n'
+    );
+    return { passed: orderedIds, deferred: [] };
+  }
+
   const closedSet = closedTaskIdSet(closedBeads);
   const closedTaskIds = [...closedSet];
 
@@ -351,9 +373,19 @@ function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, pr
   const deferred = [];
   for (const r of orderedIds) {
     const bead = eligibleMap.get(r.id);
-    const taskId = extractTaskId(bead?.title) || r.id;
+    const extracted = extractTaskId(bead?.title);
+    const taskId = extracted || r.id;
     if (selectedSet.has(taskId)) {
       passed.push(r);
+    } else if (!extracted) {
+      // The fallback to the bead id is a task id that by construction never
+      // appears in phaseTaskIds, so this bead can never be selected while the
+      // gate is live. Discarding it is deliberate — phase-tracker documents
+      // that an id with no phase mapping cannot be proven to belong to the
+      // current phase — but calling it 'phase-gate' tells an operator it is
+      // waiting on an earlier phase, when the real cause is a bead title
+      // missing its [trd:<slug>:task:<id>] marker. Name the actual cause.
+      deferred.push({ ...r, deferReason: 'unparseable-task-id' });
     } else {
       deferred.push({ ...r, deferReason: 'phase-gate' });
     }

--- a/packages/development/lib/complete-beads-planner.js
+++ b/packages/development/lib/complete-beads-planner.js
@@ -335,7 +335,15 @@ function applyPhaseFilter(orderedIds, eligibleMap, closedBeads, phaseTaskIds, pr
     readyTaskIds,
     phaseTaskIds,
     closedTaskIds,
-    { prFormat: true, max: readyTaskIds.length }
+    // `stacked`, not `prFormat`: phase-tracker renamed this option in 7b73b7a
+    // and this call site was missed. Passing the old key made
+    // `options.stacked === true` never true, so selectNextTasks fell into the
+    // unfiltered branch and phase-strict gating silently did nothing —
+    // later-phase tasks could jump the phase boundary, which is the exact bug
+    // the phase gate exists to prevent. The planner keeps `prFormat` as its own
+    // public option name (it comes from the CLI's --pr-format); only the call
+    // INTO phase-tracker uses the new key.
+    { stacked: true, max: readyTaskIds.length }
   );
   const selectedSet = new Set(selectedTaskIds);
 

--- a/packages/development/lib/trd-cli.js
+++ b/packages/development/lib/trd-cli.js
@@ -532,8 +532,11 @@ function main(argv) {
   if (!subcommand) {
     process.stdout.write(
       JSON.stringify({
+        // Lead with the machine-readable cause, then the usage. Callers (and
+        // the smoke test) match on the cause; emitting usage alone made an
+        // invocation error indistinguishable from a help request.
         error:
-          'Usage: trd-cli <parse|scaffold-plan|phase-status|next-task|pr-plan|validate-workstream|create-workstream-trd|workstream-plan|workstream-status|choices-read|choices-write> <trd-path> [...]',
+          'Missing subcommand. Usage: trd-cli <parse|scaffold-plan|phase-status|next-task|pr-plan|validate-workstream|create-workstream-trd|workstream-plan|workstream-status|choices-read|choices-write> <trd-path> [...]',
       }) + '\n'
     );
     return 1;

--- a/packages/development/skills/complete-beads/SKILL.md
+++ b/packages/development/skills/complete-beads/SKILL.md
@@ -118,7 +118,7 @@ COMPLETE_BEADS_RESULT
 ```
 
 - `complete`: every scoped descendant is closed
-- `blocked`: scoped open descendants remain but `br ready` is empty, OR all eligible candidates are deferred (phase-gate, file-claim-conflict, slot-cap)
+- `blocked`: scoped open descendants remain but `br ready` is empty, OR all eligible candidates are deferred (phase-gate, file-claim-conflict, slot-cap, unparseable-task-id — the bead title is missing its [trd:<slug>:task:<id>] marker)
 - `failed`: at least one dispatched bead could not be implemented/integrated after bounded recovery; unrelated successful results are still integrated first
 
 ---

--- a/packages/development/skills/complete-beads/SKILL.md
+++ b/packages/development/skills/complete-beads/SKILL.md
@@ -146,6 +146,7 @@ Any `propose`/`append` failure returns `failed` with current branch and already-
 ## HALT Conditions
 
 - Malformed BV JSON or missing `.plan.tracks` when ready work exists → fail closed
+- `--pr-format` with an unusable phase map (no task ids under any numeric phase) → fail closed: the map failed to load and phase-strict gating cannot be enforced without it
 - Dirty integration checkout before worktree creation → halt with diagnostic
 - `propose`/`append` failure → return `failed` with existing PR URLs
 - Worker test/validation failure: never cherry-pick; reopen/comment in separate audit commit

--- a/packages/development/tests/complete-beads-planner.test.js
+++ b/packages/development/tests/complete-beads-planner.test.js
@@ -232,13 +232,34 @@ describe('planDispatch — phase-gate deferred is NOT false-complete', () => {
     // Consumer: SKILL.md step 6 sees selected=[] && deferred>0 → status: blocked (NOT complete)
   });
 
-  // Guard: re-arming the phase gate made a MISSING phase map fatal. The CLI turns
-  // an absent phase file into `{}` (complete-beads-cli.js `phaseTaskIdsJson || {}`),
-  // and with the gate live currentPhase() returns null so EVERY ready bead is
-  // deferred 'phase-gate' — a total stall reported as "waiting on an earlier phase",
-  // exiting 0. No phase metadata means no boundaries to enforce; pass through.
-  test('empty phase map: gate does not apply, everything passes through', () => {
-    const warn = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  // Guard: prFormat is set only for TRDs with `PR N:` headings, which always
+  // yield >=1 phase — so prFormat with no phase task ids can ONLY mean the map
+  // failed to load (complete-beads-cli turns an absent file into `{}`). Fail
+  // CLOSED: passing through would silently dispatch later-phase work across a
+  // real boundary, which is the failure this whole fix exists to remove.
+  // Counts TASK IDS, not phase keys — {"1":[],"2":[]} has two keys, zero ids.
+  test.each([
+    ['empty map', {}],
+    ['undefined map', undefined],
+    ['phases present but no task ids', { 1: [], 2: [] }],
+  ])('refuses to dispatch when the phase map is unusable: %s', (_label, phaseMap) => {
+    expect(() =>
+      planDispatch(
+        { quick_ref: { total: 2, picks: [{ id: 't1' }, { id: 't2' }] } },
+        mkPlan([{ track: 0, items: [{ id: 't1' }] }, { track: 1, items: [{ id: 't2' }] }]),
+        [mkBead('t1', 'TRD-001'), mkBead('t2', 'TRD-002')],
+        [mkBead('t1', 'TRD-001'), mkBead('t2', 'TRD-002')],
+        [],
+        [],
+        2,
+        phaseMap,
+        { prFormat: true }
+      )
+    ).toThrow(/phase map contains no task ids/);
+  });
+
+  // The gate must still NOT fire when the caller never asked for phase strictness.
+  test('no --pr-format: unusable phase map is irrelevant, ids pass through', () => {
     const result = planDispatch(
       { quick_ref: { total: 2, picks: [{ id: 't1' }, { id: 't2' }] } },
       mkPlan([{ track: 0, items: [{ id: 't1' }] }, { track: 1, items: [{ id: 't2' }] }]),
@@ -248,14 +269,9 @@ describe('planDispatch — phase-gate deferred is NOT false-complete', () => {
       [],
       2,
       {},
-      { prFormat: true }
+      { prFormat: false }
     );
     expect(result.selected).toHaveLength(2);
-    expect(result.deferred).toHaveLength(0);
-    // and it must SAY so — a TRD that should have phases and silently lost them
-    // is indistinguishable from one that never had them without this line.
-    expect(warn.mock.calls.flat().join('')).toMatch(/no TRD phase metadata/);
-    warn.mockRestore();
   });
 
   // Guard: extractTaskId falls back to the bead id, which by construction never

--- a/packages/development/tests/complete-beads-planner.test.js
+++ b/packages/development/tests/complete-beads-planner.test.js
@@ -242,6 +242,7 @@ describe('planDispatch — phase-gate deferred is NOT false-complete', () => {
     ['empty map', {}],
     ['undefined map', undefined],
     ['phases present but no task ids', { 1: [], 2: [] }],
+    ['ids under a non-numeric key phase-tracker discards', { a: ['TRD-001'] }],
   ])('refuses to dispatch when the phase map is unusable: %s', (_label, phaseMap) => {
     expect(() =>
       planDispatch(

--- a/packages/development/tests/complete-beads-planner.test.js
+++ b/packages/development/tests/complete-beads-planner.test.js
@@ -232,6 +232,51 @@ describe('planDispatch — phase-gate deferred is NOT false-complete', () => {
     // Consumer: SKILL.md step 6 sees selected=[] && deferred>0 → status: blocked (NOT complete)
   });
 
+  // Guard: re-arming the phase gate made a MISSING phase map fatal. The CLI turns
+  // an absent phase file into `{}` (complete-beads-cli.js `phaseTaskIdsJson || {}`),
+  // and with the gate live currentPhase() returns null so EVERY ready bead is
+  // deferred 'phase-gate' — a total stall reported as "waiting on an earlier phase",
+  // exiting 0. No phase metadata means no boundaries to enforce; pass through.
+  test('empty phase map: gate does not apply, everything passes through', () => {
+    const warn = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = planDispatch(
+      { quick_ref: { total: 2, picks: [{ id: 't1' }, { id: 't2' }] } },
+      mkPlan([{ track: 0, items: [{ id: 't1' }] }, { track: 1, items: [{ id: 't2' }] }]),
+      [mkBead('t1', 'TRD-001'), mkBead('t2', 'TRD-002')],
+      [mkBead('t1', 'TRD-001'), mkBead('t2', 'TRD-002')],
+      [],
+      [],
+      2,
+      {},
+      { prFormat: true }
+    );
+    expect(result.selected).toHaveLength(2);
+    expect(result.deferred).toHaveLength(0);
+    // and it must SAY so — a TRD that should have phases and silently lost them
+    // is indistinguishable from one that never had them without this line.
+    expect(warn.mock.calls.flat().join('')).toMatch(/no TRD phase metadata/);
+    warn.mockRestore();
+  });
+
+  // Guard: extractTaskId falls back to the bead id, which by construction never
+  // appears in phaseTaskIds — so an unmarked title can never be selected while the
+  // gate is live. Discarding it is deliberate; calling it 'phase-gate' is not.
+  test('unparseable bead title defers with its real cause, not phase-gate', () => {
+    const result = planDispatch(
+      { quick_ref: { total: 2, picks: [{ id: 't1' }, { id: 't2' }] } },
+      mkPlan([{ track: 0, items: [{ id: 't1' }] }, { track: 1, items: [{ id: 't2' }] }]),
+      [{ id: 't1', title: 'no marker', description: '' }, { id: 't2', title: 'none either', description: '' }],
+      [{ id: 't1', title: 'no marker', description: '' }, { id: 't2', title: 'none either', description: '' }],
+      [],
+      [],
+      2,
+      { 1: ['TRD-001'], 2: ['TRD-002'] },
+      { prFormat: true }
+    );
+    expect(result.selected).toHaveLength(0);
+    expect(result.deferred.every((d) => d.deferReason === 'unparseable-task-id')).toBe(true);
+  });
+
   // Scenario: t1 is phase-1 (active), t2 is phase-2 (gated). Correct behavior: t1 passes.
   test('partial phase-gate: active-phase task passes, later-phase task deferred', () => {
     const result = planDispatch(

--- a/packages/pi/skills/complete-beads/SKILL.md
+++ b/packages/pi/skills/complete-beads/SKILL.md
@@ -152,6 +152,7 @@ Any `propose`/`append` failure returns `failed` with current branch and already-
 ## HALT Conditions
 
 - Malformed BV JSON or missing `.plan.tracks` when ready work exists → fail closed
+- `--pr-format` with an unusable phase map (no task ids under any numeric phase) → fail closed: the map failed to load and phase-strict gating cannot be enforced without it
 - Dirty integration checkout before worktree creation → halt with diagnostic
 - `propose`/`append` failure → return `failed` with existing PR URLs
 - Worker test/validation failure: never cherry-pick; reopen/comment in separate audit commit

--- a/packages/pi/skills/complete-beads/SKILL.md
+++ b/packages/pi/skills/complete-beads/SKILL.md
@@ -124,7 +124,7 @@ COMPLETE_BEADS_RESULT
 ```
 
 - `complete`: every scoped descendant is closed
-- `blocked`: scoped open descendants remain but `br ready` is empty, OR all eligible candidates are deferred (phase-gate, file-claim-conflict, slot-cap)
+- `blocked`: scoped open descendants remain but `br ready` is empty, OR all eligible candidates are deferred (phase-gate, file-claim-conflict, slot-cap, unparseable-task-id — the bead title is missing its [trd:<slug>:task:<id>] marker)
 - `failed`: at least one dispatched bead could not be implemented/integrated after bounded recovery; unrelated successful results are still integrated first
 
 ---


### PR DESCRIPTION
## Why

`main` has been red since June with 3 failing tests. They are unrelated to any open PR — including #80, which inherits them and adds **zero** new failures of its own. This clears them so #80 (and anything else) can merge against a green baseline.

## The real bug

`7b73b7a` renamed `selectNextTasks`' option from `prFormat` to `stacked` in `phase-tracker.js`. The call site in `complete-beads-planner.js:338` was missed and still passed `prFormat`.

The result: `options.stacked === true` is never true, so `selectNextTasks` takes the *unfiltered* branch and **phase-strict gating does nothing**. A later-phase task can jump ahead of an incomplete earlier phase — exactly what the gate exists to prevent.

This is silent by construction. The planner still returns a plausible selection; it is just the wrong one. `implement-trd-beads` has been running without phase enforcement since that rename.

The planner keeps `prFormat` as its own public option name (it comes from the CLI's `--pr-format`). Only the call *into* `phase-tracker` moves to the new key.

**Mutation-verified:** reverting that single word fails 2 tests.

## Second fix

`trd-cli` invoked with no subcommand emitted only a usage string, so a caller matching on the cause could not distinguish an invocation error from a help request. Now leads with `Missing subcommand.` and keeps the usage after it.

## Verification

```
CI=true npm test   →  exit 0, 0 failing suites, 722 passed
                      (main: 719 passed / 3 failed)
npm run generate   →  exit 0, no artifact drift
```

Install note for anyone reproducing: `npm ci` alone fails because five workspace packages pin `@fortium/ensemble-development@^4.0.0` against a workspace at 5.8.0. CI uses `npm ci --legacy-peer-deps`, which works. That mismatch is left alone here — separate concern, separate PR.

## Files

Two, both one-line changes plus explanatory comments.